### PR TITLE
feat: Ability to create user with view only rights

### DIFF
--- a/learnings/Permissions.md
+++ b/learnings/Permissions.md
@@ -1,0 +1,40 @@
+# permissions
+
+list -> read
+
+## Initial page with no error
+
+1. can fave slices on Superset
+1. can fave dashboards on Superset
+1. can recent activity on Superset
+
+## List of dashboards
+
+1. can list on DashboardModelViewAsync
+
+## See a dashboard
+
+1. can dashboard on Superset => for view a dashbaord
+1. can explore JSON on Superset => for viewing slice inside a chart
+1. can list on CssTemplateAsyncModelView => for template
+
+## Perm Gyaan
+
+1. is used for list view of model
+1. cam list for showing in a list
+1. can show for show buton in lits
+1. can edit for edit button in list
+
+## SEE Permissons 
+
+   ```sql
+        select ab_permission.name, ab_view_menu.name, ab_role.name from ab_permission_view JOIN ab_permission ON ab_permission_view.permission_id = ab_permission.id JOIN ab_permission_view_role on ab_permission_view.id = ab_permission_view_role.permission_view_id JOIN ab_role ON ab_role.id = ab_permission_view_role.role_id JOIN ab_view_menu ON ab_view_menu.id = ab_permission_view.view_menu_id where ab_role.name = 'Public'
+    ```
+
+    ```sql 
+    select ab_permission.name, ab_view_menu.name, ab_role.name from ab_permission_view JOIN ab_permission ON ab_permission_view.permission_id = ab_permission.id JOIN ab_permission_view_role ON ab_permission_view.id = ab_permission_view_role.permission_view_id JOIN ab_role ON ab_role.id = ab_permission_view_role.role_id JOIN ab_view_menu ON ab_view_menu.id = 
+    ab_permission_view.view_menu_id where role_id = 1;
+
+    ```
+
+  

--- a/superset/security.py
+++ b/superset/security.py
@@ -383,7 +383,7 @@ class SupersetSecurityManager(SecurityManager):
     def is_dashboard_viewer_pvm(self, pvm):
         return ( self.is_base_view_pvm(pvm) or
             pvm.permission.name in {
-                'can_dashboard', 'can_explore_json', 'can_recent_activity',
+                'can_dashboard', 'can_explore_json',
             } or (pvm.permission.name in {'can_list'} and pvm.view_menu.name in {'CssTemplateAsyncModelView', 'DashboardModelViewAsync' })
             )
 

--- a/superset/security.py
+++ b/superset/security.py
@@ -381,7 +381,7 @@ class SupersetSecurityManager(SecurityManager):
             })
 
     def is_dashboard_viewer_pvm(self, pvm):
-        return ( self.is_base_view_pvm(pvm) or
+        return ( self.is_base_view_pvm(pvm) or self.is_base_security_pvm(pvm) or
             pvm.permission.name in {
                 'can_dashboard', 'can_explore_json',
             } or (pvm.permission.name in {'can_list'} and pvm.view_menu.name in {'CssTemplateAsyncModelView', 'DashboardModelViewAsync' })
@@ -392,6 +392,15 @@ class SupersetSecurityManager(SecurityManager):
             pvm.permission.name in {
                 'can_fave_slices', 'can_fave_dashboards', 'can_recent_activity',
             })
+
+    def is_base_security_pvm(self, pvm):
+        return (
+            pvm.permission.name in {
+                'can_userinfo' , 'resetmypassword' , 'can_this_form_get' , 'can_this_form_post'
+            } and pvm.view_menu.name in { 'UserDBModelView', 'ResetMyPasswordView' } 
+            # above code will allow some options which are not in PVM 
+            # but i am shortcircuiting thsi for now as those permission will be not added to role
+            )
 
     def is_granter_pvm(self, pvm):
         return pvm.permission.name in {

--- a/superset/security.py
+++ b/superset/security.py
@@ -319,6 +319,7 @@ class SupersetSecurityManager(SecurityManager):
         self.set_role('Gamma', self.is_gamma_pvm)
         self.set_role('granter', self.is_granter_pvm)
         self.set_role('sql_lab', self.is_sql_lab_pvm)
+        self.set_role('Dashboard_Viewer', self.is_dashboard_viewer_pvm)
 
         if conf.get('PUBLIC_ROLE_LIKE_GAMMA', False):
             self.set_role('Public', self.is_gamma_pvm)
@@ -377,6 +378,19 @@ class SupersetSecurityManager(SecurityManager):
             pvm.permission.name in {
                 'can_sql_json', 'can_csv', 'can_search_queries', 'can_sqllab_viz',
                 'can_sqllab',
+            })
+
+    def is_dashboard_viewer_pvm(self, pvm):
+        return ( self.is_base_view_pvm(pvm) or
+            pvm.permission.name in {
+                'can_dashboard', 'can_explore_json', 'can_recent_activity',
+            } or (pvm.permission.name in {'can_list'} and pvm.view_menu.name in {'CssTemplateAsyncModelView', 'DashboardModelViewAsync' })
+            )
+
+    def is_base_view_pvm(self, pvm):
+        return (
+            pvm.permission.name in {
+                'can_fave_slices', 'can_fave_dashboards', 'can_recent_activity',
             })
 
     def is_granter_pvm(self, pvm):


### PR DESCRIPTION
We have introduced a new role "Dashboard_Viewer" who can only see dashboard in readonly mode.

However he need access on underlying datasource used in dashboard to view them.

I have decided against providing access to `all_datasource` to this role by default as it will not make this role Single Responsibility and devoid as opportunity for more fine grain control.


Out of scope:
Any modification on UI and its display

