### PR TITLE
Feature : add support to connect hive in http transport mode

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -52,6 +52,8 @@ SQLAlchemy-Utils = "==0.32.21"
 thrift_sasl = "==0.3.0"
 pipenv = "*"
 python-ldap = "==3.1.0"
+requests-kerberos = "==0.12.0"
+django = "==2.1.5"
 
 [dev-packages]
 "autopep8" = "==1.3.5"

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,10 @@ setup(
         'lxml==3.8.0',
         'numexpr==2.6.4',
         'xlrd==1.1.0',
-        'python-ldap==3.1.0'
+        'python-ldap==3.1.0',
+        'requests-kerberos==0.12.0',
+        'django==2.1.5'
+
     ],
     extras_require={
         'cors': ['flask-cors>=2.0.0'],

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         'idna',
         'isodate',
         'markdown<3.0.0',
-        'pandas>=0.18.0',
+        'pandas>=0.18.0, <0.24.0',
         'parsedatetime',
         'pathlib2',
         'polyline',

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1000,6 +1000,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         hive.constants = patched_constants
         hive.ttypes = patched_ttypes
         hive.Cursor.fetch_logs = patched_hive.fetch_logs
+        hive.connect = patched_hive.connect
 
     @classmethod
     @cache_util.memoized_func(

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1000,7 +1000,7 @@ class HiveEngineSpec(PrestoEngineSpec):
         hive.constants = patched_constants
         hive.ttypes = patched_ttypes
         hive.Cursor.fetch_logs = patched_hive.fetch_logs
-        hive.connect = patched_hive.connect
+        # hive.connect = patched_hive.connect
 
     @classmethod
     @cache_util.memoized_func(

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1000,7 +1000,6 @@ class HiveEngineSpec(PrestoEngineSpec):
         hive.constants = patched_constants
         hive.ttypes = patched_ttypes
         hive.Cursor.fetch_logs = patched_hive.fetch_logs
-        # hive.connect = patched_hive.connect
 
     @classmethod
     @cache_util.memoized_func(

--- a/superset/db_engines/THttpTransport/THttpClientTransport.py
+++ b/superset/db_engines/THttpTransport/THttpClientTransport.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import logging
+import io
+
+from thrift.transport.TTransport import *
+
+from superset.db_engines.THttpTransport.http_client import HttpClient
+from superset.db_engines.THttpTransport.resource import Resource
+
+
+LOG = logging.getLogger(__name__)
+
+
+class THttpClientTransport(TTransportBase):
+  """
+  HTTP transport mode for Thrift.
+
+  HTTPS and Kerberos support with Request.
+
+  e.g.
+  mode = THttpClient('http://hbase-thrift-v1.com:9090')
+  mode = THttpClient('http://hive-localhost:10001/cliservice')
+  """
+
+  def __init__(self, base_url):
+    self._base_url = base_url
+    self._client = HttpClient(self._base_url, logger=LOG)
+    self._data = None
+    self._headers = None
+    self._wbuf = io.BytesIO()
+
+  def open(self):
+    pass
+
+  def set_kerberos_auth(self,mutual_auth, principal):
+    self._client.set_kerberos_auth(mutual_auth,principal)
+
+  def set_basic_auth(self, username, password):
+    self._client.set_basic_auth(username, password)
+
+  def set_verify(self, verify=True):
+    self._client.set_verify(verify)
+
+  def close(self):
+    self._headers = None
+    # Close session too?
+
+  def isOpen(self):
+    return self._client is not None
+
+  def setTimeout(self, ms):
+    pass
+
+  def setCustomHeaders(self, headers):
+    self._headers = headers
+
+  def read(self, sz):
+    return self._data
+
+  def write(self, buf):
+    self._wbuf.write(buf)
+
+  def flush(self):
+    data = self._wbuf.getvalue()
+    self._wbuf = io.BytesIO();
+
+    # POST
+    self._root = Resource(self._client)
+    self._data = self._root.post('', data=data, headers=self._headers)

--- a/superset/db_engines/THttpTransport/THttpClientTransport.py
+++ b/superset/db_engines/THttpTransport/THttpClientTransport.py
@@ -49,8 +49,14 @@ class THttpClientTransport(TTransportBase):
   def open(self):
     pass
 
-  def set_kerberos_auth(self,mutual_auth, principal):
-    self._client.set_kerberos_auth(mutual_auth,principal)
+  def set_kerberos_auth(self,mutual_authentication,
+            service, delegate, force_preemptive,
+            principal, hostname_override,
+            sanitize_mutual_error_response, send_cbt):
+    self._client.set_kerberos_auth(mutual_authentication,
+            service, delegate, force_preemptive,
+            principal, hostname_override,
+            sanitize_mutual_error_response, send_cbt)
 
   def set_basic_auth(self, username, password):
     self._client.set_basic_auth(username, password)

--- a/superset/db_engines/THttpTransport/http_client.py
+++ b/superset/db_engines/THttpTransport/http_client.py
@@ -1,0 +1,220 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import posixpath
+import requests
+import threading
+import urllib
+
+from django.utils.encoding import iri_to_uri, smart_str
+from django.utils.http import urlencode
+
+
+from requests import exceptions
+from requests.auth import HTTPBasicAuth, HTTPDigestAuth
+from requests_kerberos import HTTPKerberosAuth, REQUIRED, OPTIONAL, DISABLED
+from urllib3.util import parse_url
+
+__docformat__ = "epytext"
+
+LOG = logging.getLogger(__name__)
+
+CACHE_SESSION = {}
+CACHE_SESSION_LOCK = threading.Lock()
+
+def get_request_session(url, logger):
+  global CACHE_SESSION, CACHE_SESSION_LOCK
+
+  if CACHE_SESSION.get(url) is None:
+    with CACHE_SESSION_LOCK:
+      CACHE_SESSION[url] = requests.Session()
+      logger.debug("Setting request Session")
+      CACHE_SESSION[url].mount(url, requests.adapters.HTTPAdapter(pool_connections=50, pool_maxsize=50))
+      logger.debug("Setting session adapter for %s" % url)
+
+  return CACHE_SESSION
+
+class RestException(Exception):
+  """
+  Any error result from the Rest API is converted into this exception type.
+  """
+  def __init__(self, error):
+    Exception.__init__(self, error)
+    self._error = error
+    self._code = None
+    self._message = str(error)
+    self._headers = {}
+
+    # Get more information if urllib2.HTTPError.
+    try:
+      self._code = error.response.status_code
+      self._headers = error.response.headers
+      self._message = self._message + '\n' + self._error.response.text
+    except AttributeError:
+      pass
+
+  def __str__(self):
+    res = self._message or ""
+    if self._code is not None:
+      res += " (error %s)" % self._code
+    return res
+
+  def get_parent_ex(self):
+    if isinstance(self._error, Exception):
+      return self._error
+    return None
+
+  @property
+  def code(self):
+    return self._code
+
+  @property
+  def message(self):
+    return self._message
+
+
+class HttpClient(object):
+  """
+  Basic HTTP client tailored for rest APIs.
+  """
+  def __init__(self, base_url, exc_class=None, logger=None):
+    """
+    @param base_url: The base url to the API.
+    @param exc_class: An exception class to handle non-200 results.
+    """
+    self._base_url = base_url.rstrip('/')
+    self._exc_class = exc_class or RestException
+    self._logger = logger or LOG
+    self._short_url = self._extract_netloc(self._base_url)
+    self._session = get_request_session(self._short_url, self._logger).get(self._short_url)
+    self._cookies = None
+
+  def _extract_netloc(self, base_url):
+    parsed_uri = parse_url(base_url)
+    short_url = '%(scheme)s://%(netloc)s' % {'scheme': parsed_uri.scheme, 'netloc': parsed_uri.netloc}
+    return short_url
+
+  def set_kerberos_auth(self,mutual_auth ,principal):
+    """Set up kerberos auth for the client, based on the current ticket."""
+    if mutual_auth == 'OPTIONAL':
+      self._session.auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL,principal=principal)
+    elif mutual_auth == 'REQUIRED':
+      self._session.auth = HTTPKerberosAuth(mutual_authentication=REQUIRED,principal=principal)
+    elif mutual_auth == 'DISABLED':
+      self._session.auth = HTTPKerberosAuth(mutual_authentication=DISABLED,principal=principal)
+    else:  
+      self._session.auth = HTTPKerberosAuth(mutual_authentication=OPTIONAL,principal=principal)
+
+    return self
+
+  def set_basic_auth(self, username, password):
+    self._session.auth = HTTPBasicAuth(username, password)
+    return self
+
+  def set_digest_auth(self, username, password):
+    self._session.auth = HTTPDigestAuth(username, password)
+    return self
+
+  def set_headers(self, headers):
+    """
+    Add headers to the request
+    @param headers: A dictionary with the key value pairs for the headers
+    @return: The current object
+    """
+    self._session.headers.update(headers)
+    return self
+
+
+  @property
+  def base_url(self):
+    return self._base_url
+
+  @property
+  def logger(self):
+    return self._logger
+
+  def set_verify(self, verify=True):
+    self._session.verify = verify
+    return self
+      
+  def _get_headers(self, headers):
+    if headers:
+      self._session.headers.update(headers)
+    return self._session.headers.copy()
+
+  def execute(self, http_method, path, params=None, data=None, headers=None, allow_redirects=False, urlencode=True,
+              files=None, clear_cookies=False, timeout=120):
+    """
+    Submit an HTTP request.
+    @param http_method: GET, POST, PUT, DELETE
+    @param path: The path of the resource. Unsafe characters will be quoted.
+    @param params: Key-value parameter data.
+    @param data: The data to attach to the body of the request.
+    @param headers: The headers to set for this request.
+    @param allow_redirects: requests should automatically resolve redirects.
+    @param urlencode: percent encode paths.
+    @param files: for posting Multipart-Encoded files
+    @param clear_cookies: flag to force clear any cookies set in the current session
+
+    @return: The result of urllib2.urlopen()
+    """
+    # Prepare URL and params
+    if urlencode:
+      path = urllib.parse.quote(smart_str(path))
+    url = self._make_url(path, params)
+    if http_method in ("GET", "DELETE"):
+      if data is not None:
+        self.logger.warn("GET and DELETE methods do not pass any data. Path '%s'" % path)
+        data = None
+
+    request_kwargs = {'allow_redirects': allow_redirects, 'timeout': timeout}
+    if headers:
+      request_kwargs['headers'] = headers
+    if data:
+      request_kwargs['data'] = data
+    if files:
+      request_kwargs['files'] = files
+
+    if self._cookies and not clear_cookies:
+      request_kwargs['cookies'] = self._cookies
+
+    if clear_cookies:
+      self._session.cookies.clear()
+
+    try:
+      resp = getattr(self._session, http_method.lower())(url, **request_kwargs)
+      if resp.status_code >= 300:
+        resp.raise_for_status()
+        raise exceptions.HTTPError(response=resp)
+      # Cache request cookie for the next http_client call.
+      self._cookies = resp.cookies
+      return resp
+    except (exceptions.ConnectionError,
+            exceptions.HTTPError,
+            exceptions.RequestException,
+            exceptions.URLRequired,
+            exceptions.TooManyRedirects) as ex :
+      raise self._exc_class(ex)
+
+  def _make_url(self, path, params):
+    res = self._base_url
+    if path:
+      res += posixpath.normpath('/' + path.lstrip('/'))
+    if params:
+      param_str = urlencode(params)
+      res += '?' + param_str
+    return iri_to_uri(res)

--- a/superset/db_engines/THttpTransport/resource.py
+++ b/superset/db_engines/THttpTransport/resource.py
@@ -1,0 +1,210 @@
+# Licensed to Cloudera, Inc. under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  Cloudera, Inc. licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import posixpath
+import time
+
+import django.utils.encoding
+
+LOG = logging.getLogger(__name__)
+
+
+def smart_unicode(s, strings_only=False, errors='strict', encoding='utf-8'):
+  """
+  Wrapper around Django's version, while supplying our configured encoding.
+  Decode char array to unicode.
+  """
+  return django.utils.encoding.smart_text(
+        s, encoding , strings_only, errors)
+
+class Resource(object):
+  """
+  Encapsulates a resource, and provides actions to invoke on it.
+  """
+  def __init__(self, client, relpath="", urlencode=True):
+    """
+    @param client: A Client object.
+    @param relpath: The relative path of the resource.
+    @param urlencode: percent encode paths.
+    """
+    self._client = client
+    self._path = relpath.strip('/')
+    self._urlencode = urlencode
+
+  @property
+  def base_url(self):
+    return self._client.base_url
+
+  def _join_uri(self, relpath):
+    if relpath is None:
+      return self._path
+    return self._path + posixpath.normpath('/' + relpath)
+
+  def _format_response(self, resp):
+    """
+    Decide whether the body should be a json dict or string
+    """
+
+    if resp.headers.get('location') and resp.headers.get('location').startswith('http://localhost:8080/'):
+      return resp.headers.get('location').split('sessions/')[1]
+
+    if len(resp.content) != 0 and resp.headers.get('content-type') and \
+          'application/json' in resp.headers.get('content-type'):
+      try:
+        return resp.json()
+      except Exception as ex:
+        self._client.logger.exception('JSON decode error: %s' % resp.content)
+        raise ex
+    else:
+      return resp.content
+
+  def invoke(self, method, relpath=None, params=None, data=None, headers=None, files=None, allow_redirects=False, clear_cookies=False, log_response=True):
+    resp = self._invoke(method=method,
+                        relpath=relpath,
+                        params=params,
+                        data=data,
+                        headers=headers,
+                        files=files,
+                        allow_redirects=allow_redirects,
+                        clear_cookies=clear_cookies,
+                        log_response=log_response)
+
+    return self._format_response(resp)
+
+  def _invoke(self, method, relpath=None, params=None, data=None, headers=None, files=None, allow_redirects=False, clear_cookies=False, log_response=True):
+    """
+    Invoke an API method.
+    @return: Raw body or JSON dictionary (if response content type is JSON).
+    """
+    path = self._join_uri(relpath)
+    start_time = time.time()
+    resp = self._client.execute(method,
+                                path,
+                                params=params,
+                                data=data,
+                                headers=headers,
+                                files=files,
+                                allow_redirects=allow_redirects,
+                                urlencode=self._urlencode,
+                                clear_cookies=clear_cookies)
+
+    if log_response:
+      log_length = 2000
+      duration = time.time() - start_time
+      message = "%s %s Got response%s: %s%s" % (
+          method,
+          smart_unicode(path, errors='ignore'),
+          ' in %dms' % (duration * 1000),
+          smart_unicode(resp.content[:log_length or None], errors='replace'),
+          log_length and len(resp.content) > log_length and "..." or ""
+      )
+      self._client.logger.disabled = 0
+      log_if_slow_call(duration=duration, message=message, logger=self._client.logger)
+
+    return resp
+
+
+  def get(self, relpath=None, params=None, headers=None, clear_cookies=False):
+    """
+    Invoke the GET method on a resource.
+    @param relpath: Optional. A relative path to this resource's path.
+    @param params: Key-value data.
+    @param clear_cookies: Optional. A flag to force any session cookies to be reset on the request.
+
+    @return: A dictionary of the JSON result.
+    """
+    return self.invoke("GET", relpath, params, headers=headers, allow_redirects=True, clear_cookies=clear_cookies)
+
+
+  def delete(self, relpath=None, params=None, headers=None, clear_cookies=False):
+    """
+    Invoke the DELETE method on a resource.
+    @param relpath: Optional. A relative path to this resource's path.
+    @param params: Key-value data.
+    @param headers: Optional. Base set of headers.
+    @param clear_cookies: Optional. A flag to force any session cookies to be reset on the request.
+
+    @return: A dictionary of the JSON result.
+    """
+    return self.invoke("DELETE", relpath, params, headers=headers, clear_cookies=clear_cookies)
+
+
+  def post(self, relpath=None, params=None, data=None, contenttype=None, headers=None, files=None, allow_redirects=False,
+           clear_cookies=False, log_response=True):
+    """
+    Invoke the POST method on a resource.
+    @param relpath: Optional. A relative path to this resource's path.
+    @param params: Key-value data.
+    @param data: Optional. Body of the request.
+    @param contenttype: Optional.
+    @param headers: Optional. Base set of headers.
+    @param allow_redirects: Optional. Allow request to automatically resolve redirects.
+    @param clear_cookies: Optional. A flag to force any session cookies to be reset on the request.
+
+    @return: A dictionary of the JSON result.
+    """
+    return self.invoke("POST", relpath, params, data, headers=self._make_headers(contenttype, headers), files=files,
+                       allow_redirects=allow_redirects, clear_cookies=clear_cookies, log_response=log_response)
+
+
+  def put(self, relpath=None, params=None, data=None, contenttype=None, allow_redirects=False, clear_cookies=False, headers=None):
+    """
+    Invoke the PUT method on a resource.
+    @param relpath: Optional. A relative path to this resource's path.
+    @param params: Key-value data.
+    @param data: Optional. Body of the request.
+    @param contenttype: Optional.
+    @param allow_redirects: Optional. Allow request to automatically resolve redirects.
+    @param clear_cookies: Optional. A flag to force any session cookies to be reset on the request.
+
+    @return: A dictionary of the JSON result.
+    """
+    return self.invoke("PUT", relpath, params, data, headers=self._make_headers(contenttype, headers),
+                       allow_redirects=allow_redirects, clear_cookies=clear_cookies)
+
+
+  def _make_headers(self, contenttype=None, headers=None):
+    if headers is None:
+      headers = {}
+
+    if contenttype:
+      headers.update({'Content-Type': contenttype})
+
+    return headers
+
+  def resolve_redirect_url(self, method="GET", relpath=None, params=None, data=None, headers=None, files=None, allow_redirects=True, clear_cookies=False, log_response=True):
+    resp = self._invoke(method=method,
+                        relpath=relpath,
+                        params=params,
+                        data=data,
+                        headers=headers,
+                        files=files,
+                        allow_redirects=allow_redirects,
+                        clear_cookies=clear_cookies,
+                        log_response=log_response)
+
+    return resp.url.encode("utf-8")
+
+
+# Same in thrift_util.py for not losing the trace class
+def log_if_slow_call(duration, message, logger):
+  if duration >= 5:
+    logger.warn('SLOW: %.2f - %s' % (duration, message))
+  elif duration >= 1:
+    logger.info('SLOW: %.2f - %s' % (duration, message))
+  else:
+    logger.debug(message)

--- a/superset/db_engines/THttpTransport/resource.py
+++ b/superset/db_engines/THttpTransport/resource.py
@@ -21,7 +21,9 @@ import time
 import django.utils.encoding
 
 LOG = logging.getLogger(__name__)
-
+REST_RESPONSE_SIZE = 2000
+WARN_LEVEL_CALL_DURATION_MS = 5000
+INFO_LEVEL_CALL_DURATION_MS = 1000
 
 def smart_unicode(s, strings_only=False, errors='strict', encoding='utf-8'):
   """
@@ -103,7 +105,7 @@ class Resource(object):
                                 clear_cookies=clear_cookies)
 
     if log_response:
-      log_length = 2000
+      log_length = REST_RESPONSE_SIZE
       duration = time.time() - start_time
       message = "%s %s Got response%s: %s%s" % (
           method,
@@ -202,9 +204,9 @@ class Resource(object):
 
 # Same in thrift_util.py for not losing the trace class
 def log_if_slow_call(duration, message, logger):
-  if duration >= 5:
+  if duration >= WARN_LEVEL_CALL_DURATION_MS / 1000 :
     logger.warn('SLOW: %.2f - %s' % (duration, message))
-  elif duration >= 1:
+  elif duration >= INFO_LEVEL_CALL_DURATION_MS / 1000 :
     logger.info('SLOW: %.2f - %s' % (duration, message))
   else:
     logger.debug(message)

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -48,3 +48,32 @@ def fetch_logs(self, max_rows=1024,
             if not new_logs:
                 break
         return '\n'.join(logs)
+
+
+def connect(*args, **kwargs):
+    print(kwargs)
+    kwargs['transportMode'] = 'http'
+    #if 'transportMode' in kwargs and kwargs['transportMode'] == 'http':
+    params = ['host', 'username', 'password', 'port', 'httpPath', 'transportMode']
+    kwargs['thrift_transport'] = add_http_mode(
+        **dict(filter(lambda i: i[0] in params, kwargs.items())))
+    # remove unnecessary keys
+    for param in params:
+        kwargs.pop(param, None)
+    return hive.Connection(*args, **kwargs)
+
+
+def add_http_mode(username='', password='', port=10001,
+                  httpPath='/cliservice', host='127.0.0.1',
+                  transportMode='http'):
+    ap = '%s:%s' % (username, password)
+    import base64
+    from thrift.transport.THttpClient import THttpClient
+    _transport = THttpClient(host, port=port, path=httpPath)
+    _transport.setCustomHeaders({'Authorization': 'Basic '+base64.b64encode(ap).strip()})
+    #base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
+    #header = ("Authorization: Basic %s" % base64string) 
+    return bytes(_transport, 'utf-8')
+
+
+  

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -70,10 +70,10 @@ def add_http_mode(username='', password='', port=10001,
     import base64
     from thrift.transport.THttpClient import THttpClient
     _transport = THttpClient(host, port=port, path=httpPath)
-    _transport.setCustomHeaders({'Authorization': 'Basic '+base64.b64encode(ap).strip()})
-    #base64string = base64.encodestring('%s:%s' % (username, password)).replace('\n', '')
-    #header = ("Authorization: Basic %s" % base64string) 
-    return bytes(_transport, 'utf-8')
+    #_transport.setCustomHeaders({'Authorization': 'Basic '+base64.b64encode(ap).strip()})
+    credentials = base64.b64encode(ap.encode('utf-8'))
+    _transport.setCustomHeaders({"Authorization": "Basic " + credentials.decode('utf-8')})
 
+    return _transport
 
   

--- a/superset/db_engines/hive.py
+++ b/superset/db_engines/hive.py
@@ -61,7 +61,7 @@ def update_connect_args(url , connect_args):
         return        
 
 def get_http_thrift_transport(url , kwargs):
-    if ( 'transport_mode' in kwargs  and  kwargs['transport_mode'] == 'http' ):
+    if ( 'transport_mode' in kwargs  and  kwargs['transport_mode'].lower() == 'http' ):
         host = url.host
         port = url.port
         username = url.username
@@ -70,30 +70,60 @@ def get_http_thrift_transport(url , kwargs):
         if(password is None):
            password = 'x'
 
+        #  expose kerberos specific variables and set default values HTTPKerberosAuth class 
         http_path = 'cliservice' 
         if('http_path' in kwargs):
             http_path = kwargs['http_path']
-              
-        kerberos_service_name = None
-        if('kerberos_service_name' in kwargs):
-            kerberos_service_name = kwargs['kerberos_service_name']
 
-        mutual_auth = 'OPTIONAL'
-        if('mutual_auth' in kwargs):
-            mutual_auth = kwargs['mutual_auth']
+        #  set principal value used in http mode 
+        principal = None
+        if('principal' in kwargs):
+            principal = kwargs['principal']
+
+        mutual_authentication = 'OPTIONAL'
+        if('mutual_authentication' in kwargs):
+            mutual_authentication = kwargs['mutual_authentication']
+
+        service = "HTTP" 
+        if('service' in kwargs):
+            service = kwargs['service']
+
+        delegate = False
+        if('delegate' in kwargs):
+            delegate = kwargs['delegate']
+
+        force_preemptive = False
+        if('force_preemptive' in kwargs):
+            force_preemptive = kwargs['force_preemptive']
+
+        hostname_override=None
+        if('hostname_override' in kwargs):
+            hostname_override = kwargs['hostname_override']
+
+        sanitize_mutual_error_response=True
+        if('sanitize_mutual_error_response' in kwargs):
+            sanitize_mutual_error_response = kwargs['sanitize_mutual_error_response']
+
+        send_cbt=True
+        if('send_cbt' in kwargs):
+            send_cbt = kwargs['send_cbt']    
 
         auth = "NONE"
         if('auth' in kwargs):
             auth = kwargs['auth']
+           
         
         client = THttpClientTransport("http://{}:{}/{}".format(host, port, http_path))
         if auth == 'KERBEROS':
-            client.set_kerberos_auth(mutual_auth,kerberos_service_name)
+            client.set_kerberos_auth(mutual_authentication,
+            service, delegate, force_preemptive,
+            principal, hostname_override,
+            sanitize_mutual_error_response, send_cbt)
         else:  
             client.set_basic_auth(username, password)  
 
         # remove custom vars not req in phive 
-        exrta_params = ['transport_mode','mutual_auth','http_path']   
+        exrta_params = ['principal','transport_mode','mutual_authentication','http_path','service','delegate','force_preemptive','hostname_override','sanitize_mutual_error_response','send_cbt']   
         for param in exrta_params:
             kwargs.pop(param, None)
        

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -50,6 +50,7 @@ custom_password_store = config.get('SQLALCHEMY_CUSTOM_PASSWORD_STORE')
 stats_logger = config.get('STATS_LOGGER')
 metadata = Model.metadata  # pylint: disable=no-member
 from superset.models.helpers import has_kerberos_ticket
+from superset.db_engines.hive import update_connect_args
 
 PASSWORD_MASK = 'X' * 10
 
@@ -762,6 +763,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
                 effective_username))
         if configuration:
             params['connect_args'] = {'configuration': configuration}
+
+        update_connect_args(url,params['connect_args'])
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -50,7 +50,7 @@ custom_password_store = config.get('SQLALCHEMY_CUSTOM_PASSWORD_STORE')
 stats_logger = config.get('STATS_LOGGER')
 metadata = Model.metadata  # pylint: disable=no-member
 from superset.models.helpers import has_kerberos_ticket
-from superset.db_engines.hive import update_connect_args
+from superset.db_engines.hive import get_updated_connect_args,remove_http_params_from
 
 PASSWORD_MASK = 'X' * 10
 
@@ -765,7 +765,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
             params['connect_args'] = {'configuration': configuration}
 
         if('connect_args' in params):
-            update_connect_args(url,params['connect_args'])
+            params['connect_args'].update(get_updated_connect_args(url,params['connect_args']))
+            remove_http_params_from(url,connect_args)
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -766,7 +766,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
         if('connect_args' in params):
             params['connect_args'].update(get_updated_connect_args(url,params['connect_args']))
-            remove_http_params_from(url,connect_args)
+            remove_http_params_from(url,params['connect_args'])
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -764,7 +764,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
         if configuration:
             params['connect_args'] = {'configuration': configuration}
 
-        update_connect_args(url,params['connect_args'])
+        if('connect_args' in params):
+            update_connect_args(url,params['connect_args'])
 
         DB_CONNECTION_MUTATOR = config.get('DB_CONNECTION_MUTATOR')
         if DB_CONNECTION_MUTATOR:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -62,6 +62,7 @@ from .base import (
 )
 from .utils import bootstrap_user_data
 from superset.views.superset_decorators import redirect_to_target_url
+from superset.db_engines.hive import update_connect_args
 
 config = app.config
 stats_logger = config.get('STATS_LOGGER')
@@ -1707,6 +1708,9 @@ class Superset(BaseSupersetView):
                 .get('extras', {})
                 .get('engine_params', {})
                 .get('connect_args', {}))
+
+            
+            update_connect_args(make_url(uri),connect_args)
 
             if configuration:
                 connect_args['configuration'] = configuration

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -62,7 +62,7 @@ from .base import (
 )
 from .utils import bootstrap_user_data
 from superset.views.superset_decorators import redirect_to_target_url
-from superset.db_engines.hive import update_connect_args
+from superset.db_engines.hive import get_updated_connect_args, remove_http_params_from
 
 config = app.config
 stats_logger = config.get('STATS_LOGGER')
@@ -1687,9 +1687,10 @@ class Superset(BaseSupersetView):
                     uri = database.sqlalchemy_uri_decrypted
 
             configuration = {}
+        
+            url = make_url(uri)
 
             if database and uri:
-                url = make_url(uri)
                 db_engine = models.Database.get_db_engine_spec_for_backend(
                     url.get_backend_name())
                 db_engine.patch()
@@ -1709,8 +1710,8 @@ class Superset(BaseSupersetView):
                 .get('engine_params', {})
                 .get('connect_args', {}))
 
-            
-            update_connect_args(make_url(uri),connect_args)
+            connect_args.update(get_updated_connect_args(url,connect_args))
+            remove_http_params_from(url,connect_args)
 
             if configuration:
                 connect_args['configuration'] = configuration


### PR DESCRIPTION
Add support to connect hive from superset in http transport mode

1. currently support only HTTP scheme with NONE|Kerberos Authentication
2. mandatory vars to set args  value while setting  db connection 
                     "transport_mode": "http",
                     "auth": "KERBEROS" . (set this only if kerberos auth needed)

3. Additional vars exposed as per HTTPKerberosAuth class which may required to set connect with kerberos auth
  "principal":"hive",
  "service":"http",
 "delegate":"False",
 "force_preemptive":"true",
 "mutual_authentication":"OPT",
 "hostname_override":"sdad",
 "sanitize_mutual_error_response":"false",
 "send_cbt":"true",
 "http_path":"ser"

for more about kerberos auth params details read here
https://github.com/requests/requests-kerberos

Tested and validated as per guavus kerberos setup machine