### PR TITLE
fix(upgrade): updated regex of  time range query where clause to hive partition based query

### DIFF
--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -88,8 +88,10 @@ def defaultHiveQueryGenerator(sql, query_obj,database):
                 if timeSeq and len(timeSeq) > 1 :
                    whereClause = " ( " + whereClause + " ) "
             
-                regex_st = "(`)((?:[a-z][a-z]+))(`)(\\s+)(>)(=)(\\s+)([+-]?\\d*\\.\\d+)(?![-+0-9\\.])"
-                regex_et = "(AND)(\\s+)(`)((?:[a-z][a-z]+))(`)(\\s+)(<)(=)(\\s+)([+-]?\\d*\\.\\d+)(?![-+0-9\\.])"
+                # regex for  `columname` >= 1549497600 type of string
+                regex_st = "(`)((?:[a-z][a-z]+))(`)(\\s+)(>)(=)(\\s+)(\\d+)"
+                # regex for `columname` <= 1549497600
+                regex_et = "(AND)(\\s+)(`)((?:[a-z][a-z]+))(`)(\\s+)(<)(=)(\\s+)(\\d+)"
             
                 sql_updated = re.sub(regex_st, whereClause, sql)
                 sql_updated = re.sub(regex_et, '\n', sql_updated)


### PR DESCRIPTION
updated regex of  time range query where clause to hive partition based query

because of superset upgrade  epoch  format changes from float to int, so update regex

UIC-1003