### PR TITLE
#[UIC-1067] fix(deployment) secured sensitive info in deployment file

### DIFF
--- a/superset-installer/etc/reflex-provisioner/inventory/templates/group_vars/global/all/raf/superset.yml
+++ b/superset-installer/etc/reflex-provisioner/inventory/templates/group_vars/global/all/raf/superset.yml
@@ -94,8 +94,6 @@ SUPERSET_AUTH_USER_REGISTRATION: True
 SUPERSET_AUTH_USER_REGISTRATION_ROLE: "Dashboard_Viewer"
 SUPERSET_AUTH_LDAP_USE_TLS: False
 SUPERSET_AUTH_LDAP_SERVER: "" # ldap://guavus.com:389 (Define the DN for the user that will be used for the initial LDAP BIND. This is necessary for OpenLDAP and can be used on MSFT AD.)
-SUPERSET_AUTH_LDAP_BIND_USER: "" # cn=Ankur Singhal,ou=gurgaon,ou=India,ou=UserIDs,dc=guavus,dc=com
-SUPERSET_AUTH_LDAP_BIND_PASSWORD: "" # Define password for the bind user.
 
 SUPERSET_AUTH_LDAP_TLS_DEMAND: False
 SUPERSET_AUTH_LDAP_TLS_CACERTDIR: "/etc/cert/"

--- a/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/templates/superset-deployment.yaml.j2
+++ b/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/templates/superset-deployment.yaml.j2
@@ -27,11 +27,17 @@ spec:
         - name: POSTGRES_HOST
           value: "{{ superset_postgres_access_ip }}"
         - name: POSTGRES_PASSWORD
-          value: {{ superset_postgres_db_password }}
+          valueFrom:
+            secretKeyRef:
+              name: psql-secret
+              key: POSTGRES_PASSWORD
         - name: POSTGRES_PORT
           value: "{{ superset_postgres_access_port }}"
         - name: POSTGRES_USER
-          value: {{ superset_postgres_db_user }}
+          valueFrom:
+            secretKeyRef:
+              name: psql-secret
+              key: POSTGRES_USER
         - name: REDIS_HOST
           value: redis
         - name: REDIS_PORT
@@ -55,9 +61,15 @@ spec:
         - name: AUTH_LDAP_SERVER
           value: "{{ SUPERSET_AUTH_LDAP_SERVER }}"
         - name: AUTH_LDAP_BIND_USER
-          value: "{{ SUPERSET_AUTH_LDAP_BIND_USER }}"
+          valueFrom:
+            secretKeyRef:
+              name: ldap-secret
+              key: username
         - name: AUTH_LDAP_BIND_PASSWORD
-          value: "{{ SUPERSET_AUTH_LDAP_BIND_PASSWORD }}"
+          valueFrom:
+            secretKeyRef:
+              name: ldap-secret
+              key: password
         - name: AUTH_LDAP_TLS_DEMAND
           value: "{{ SUPERSET_AUTH_LDAP_TLS_DEMAND }}"
         - name: AUTH_LDAP_TLS_CACERTDIR


### PR DESCRIPTION
used secret to secure sensitive info in deployment file

UIC-1067

Docs updated:--
https://guavus.atlassian.net/wiki/spaces/CU/pages/71368884/Self+Service+UI+Installation+Guide


Track  Failure  :-- if some one does not create secret as per doc prerequisite
there will be following type of error 
**while get pod**
superset-69f7bf6f57-mtc8r   0/1       CreateContainerConfigError   0          15s

**in describe pod** 
Warning  Failed                 8s (x4 over 36s)   kubelet, um002-mst-01  Error: secrets "ldap-secret" not found
Warning  Failed                 7s (x5 over 44s)  kubelet, um002-mst-01  Error: secrets "psql-secret" not found
