### PR TITLE
#[UIC-957] HTTPS service name should not have upper case letter and spaces

### DIFF
--- a/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/templates/superset-service.yaml.j2
+++ b/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/templates/superset-service.yaml.j2
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ superset_kube_namespace }}
 spec:
   ports:
-  - name: "Superset service"
+  - name: "superset-service"
     protocol: TCP
     port: {{ superset_service_port }}
     targetPort: {{ superset_nginx_port }}


### PR DESCRIPTION
UIC-956