### PR TITLE
#[UIC-1025] #fix Add missing var in config to change the title to ease rebranded deployment

### DIFF
--- a/docker/superset_config.py
+++ b/docker/superset_config.py
@@ -35,6 +35,9 @@ LOG_LEVEL = boolify(get_env_variable('LOG_LEVEL'))
 SESSION_LIFETIME_SECONDS = eval(get_env_variable('SESSION_LIFETIME_SECONDS'))
 PERMANENT_SESSION_LIFETIME = timedelta(seconds=SESSION_LIFETIME_SECONDS)
 
+# Change application name
+APP_NAME = get_env_variable('APP_NAME')
+
 # LDAP configuration
 AUTH_TYPE = eval(get_env_variable('AUTH_TYPE'))
 


### PR DESCRIPTION
Description

Add missing var in config to change the title to ease rebranded deployment

Replace the value of the var name RVF_APP_NAME while doing deployment via global group vars in superset.yml file

Default value of RVF_APP_NAME is "Dashboard Builder".