### PR TITLE
#[UIC-1146] Add time based Hive partition support #design-proposal

### DIFF
--- a/learnings/hive-partitions.md
+++ b/learnings/hive-partitions.md
@@ -1,1 +1,0 @@
-# Its's dummy commit to raise Draft PR

--- a/learnings/hive-partitions.md
+++ b/learnings/hive-partitions.md
@@ -1,0 +1,1 @@
+# Its's dummy commit to raise Draft PR

--- a/superset/config.py
+++ b/superset/config.py
@@ -27,7 +27,7 @@ import json
 import os
 import sys
 
-from superset.hive_query import defaultHiveQueryGenerator
+from superset.hive_query import default_hive_query_generator
 from celery.schedules import crontab
 from dateutil import tz
 from datetime import datetime
@@ -589,10 +589,10 @@ IS_EPOCH_S_TRULY_UTC = False
 
 # A function that intercepts the SQL to be executed and can alter it.
 #
-#    def HIVE_QUERY_GENERATOR(sql, query_obj):
+#    def HIVE_QUERY_GENERATOR(sql, query_obj,database,datasource_name):
 #        dttm = datetime.now().isoformat()
 #        return sql +" WHERE XYZ > 0 "
-HIVE_QUERY_GENERATOR  = defaultHiveQueryGenerator
+HIVE_QUERY_GENERATOR  = default_hive_query_generator
 
 try:
     if CONFIG_PATH_ENV_VAR in os.environ:

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -281,6 +281,8 @@ class SqlaTable(Model, BaseDatasource):
     sql = Column(Text)
     is_sqllab_view = Column(Boolean, default=False)
     template_params = Column(Text)
+    #add hive_partitions column to store partition info
+    hive_partitions = Column(Text)
 
     baselink = 'tablemodelview'
 
@@ -288,7 +290,7 @@ class SqlaTable(Model, BaseDatasource):
         'table_name', 'main_dttm_col', 'description', 'default_endpoint',
         'database_id', 'offset', 'cache_timeout', 'schema',
         'sql', 'params', 'template_params', 'filter_select_enabled',
-        'fetch_values_predicate',
+        'fetch_values_predicate','hive_partitions',
     )
     update_from_object_fields = [
         f for f in export_fields if f not in ('table_name', 'database_id')]

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -830,11 +830,13 @@ class SqlaTable(Model, BaseDatasource):
         error_message = None
         df = None
         
+        logging.info('[PERFORMANCE CHECK] SQL Query formation time {0} '.format(datetime.now() - qry_start_dttm))
+        
         """Apply HIVE_QUERY_GENERATOR """
         HIVE_QUERY_GENERATOR = config.get('HIVE_QUERY_GENERATOR')
         if HIVE_QUERY_GENERATOR:
             sql = HIVE_QUERY_GENERATOR(sql,query_obj,self.database,self.datasource_name)
-            
+
         db_engine_spec = self.database.db_engine_spec
         try:
             df = self.database.get_df(sql, self.schema)

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -833,7 +833,7 @@ class SqlaTable(Model, BaseDatasource):
         """Apply HIVE_QUERY_GENERATOR """
         HIVE_QUERY_GENERATOR = config.get('HIVE_QUERY_GENERATOR')
         if HIVE_QUERY_GENERATOR:
-            sql = HIVE_QUERY_GENERATOR(sql,query_obj,self.database)
+            sql = HIVE_QUERY_GENERATOR(sql,query_obj,self.database,self.datasource_name)
             
         db_engine_spec = self.database.db_engine_spec
         try:

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -183,7 +183,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         'fetch_values_predicate', 'database', 'schema',
         'description', 'owners',
         'main_dttm_col', 'default_endpoint', 'offset', 'cache_timeout',
-        'is_sqllab_view', 'template_params',
+        'is_sqllab_view', 'template_params','hive_partitions',
     ]
     base_filters = [['id', DatasourceFilter, lambda: []]]
     show_columns = edit_columns + ['perm', 'slices']
@@ -237,6 +237,13 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
             'Duration (in seconds) of the caching timeout for this table. '
             'A timeout of 0 indicates that the cache never expires. '
             'Note this defaults to the database timeout if undefined.'),
+        'hive_partitions': _(
+            'Define Hive Partitions as per schema .'
+            '{"time":{"year":"_hive_year_col","month":"_hive_month_col","day":"_hive_day_col",'
+            '"hour":"_hive_hour_col","minute":"_hive_minute_col"},} '
+            'It is TIME based partitions schema sample( here time is used as key ) and mapped hive '
+            'column name with respective properties .' ),
+           
     }
     label_columns = {
         'slices': _('Associated Charts'),
@@ -258,6 +265,7 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
         'is_sqllab_view': _('SQL Lab View'),
         'template_params': _('Template parameters'),
         'modified': _('Modified'),
+        'hive_partitions': _('Hive Partitions')
     }
 
     def pre_add(self, table):

--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -239,8 +239,8 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
             'Note this defaults to the database timeout if undefined.'),
         'hive_partitions': _(
             'Define Hive Partitions as per schema .'
-            '{"time":{"year":"_hive_year_col","month":"_hive_month_col","day":"_hive_day_col",'
-            '"hour":"_hive_hour_col","minute":"_hive_minute_col"},} '
+            ' {"time":{"year":"_hive_year_col","month":"_hive_month_col","day":"_hive_day_col",'
+            '"hour":"_hive_hour_col","minute":"_hive_minute_col"}} '
             'It is TIME based partitions schema sample( here time is used as key ) and mapped hive '
             'column name with respective properties .' ),
            

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -1,6 +1,8 @@
 import json
 import re
 from datetime import timedelta
+import logging
+from datetime import datetime
 #gran valaue map,supported grain by hive db engine
 GRAN_VALUE_MAP = {
     'PT1S' : 1,
@@ -70,7 +72,6 @@ def replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_i
         sql_updated = re.sub(regex_et, '\n', sql_updated)
     else:
         sql_updated = sql.replace("WHERE", " WHERE "+ where_clause +" AND ")
-
     return sql_updated
 
 def get_hive_partitions(database, datasource_name):
@@ -108,7 +109,13 @@ def default_hive_query_generator(sql, query_obj, database, datasource_name):
                 granularity = query_obj['granularity']
                 granularity_in_partitions = (granularity in time_partitions)
                 if st and en and gran_seconds:
+                    dt = datetime.today()
+                    st_seconds = dt.timestamp()
                     where_clause = get_partitioned_whereclause(st, en, gran_seconds, time_partitions)
-                    return replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
+                    sql_updated = replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
+                    dt = datetime.today()
+                    ed_seconds = dt.timestamp()
+                    logging.info('[HIVE PARTITION QUERY] query formation time {0} seconds'.format(ed_seconds-st_seconds))
+                    return sql_updated
 
     return sql

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -54,9 +54,8 @@ def get_partitions_min_grain(time_partitions):
     if 'minute' in time_partitions:
         partition_grains.append(GRAIN_VALUE_MAP['PT1M'])
 
-    partition_grains.sort()
     if partition_grains:
-        return partition_grains[0]
+        return partition_grains[-1]
 
     return None
 

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -22,41 +22,43 @@ from datetime import timedelta
 import logging
 from datetime import datetime
 #gran valaue map,supported grain by hive db engine
-GRAN_VALUE_MAP = {
+GRAIN_VALUE_MAP = {
     'PT1S' : 1,
     'PT1M' : 60,
     'PT1H' : 3600,
     'P1D'  : 86400,
-    'P1W'  : 604800,
-    'P1M'  : 2629743,
-    'P3M'  : 7889229,
-    'P0.25Y': 7889229,
-    'P1Y'  : 31556926
+    'P1W'  : 604800,   # 7 days
+    'P1M'  : 2592000,  # 30 days
+    'P3M'  : 7776000,  # 3*30 days
+    'P0.25Y': 7776000, # 3*30 days
+    'P1Y'  : 31536000  # 365 days
 }
 
 # return seconds from gran valaue map default is 86400
 def get_gran_value_in_seconds(value,time_partitions):
     partition_min_grain = get_partitions_min_grain(time_partitions)
-    if value in GRAN_VALUE_MAP and  GRAN_VALUE_MAP[value] >= partition_min_grain:
-        return GRAN_VALUE_MAP[value]
+    if partition_min_grain and value in GRAIN_VALUE_MAP and  GRAIN_VALUE_MAP[value] >= partition_min_grain:
+        return GRAIN_VALUE_MAP[value]
     return partition_min_grain
 
 def get_partitions_min_grain(time_partitions):
     partition_grains = list()
     if 'year' in time_partitions:
-        partition_grains.append(31556926)
+        partition_grains.append(GRAIN_VALUE_MAP['P1Y'])
     if 'month' in time_partitions:
-        partition_grains.append(2629743)
+        partition_grains.append(GRAIN_VALUE_MAP['P1M'])
     if 'day' in time_partitions:
-        partition_grains.append(86400)
+        partition_grains.append(GRAIN_VALUE_MAP['P1D'])
     if 'hour' in time_partitions:
-        partition_grains.append(3600)
+        partition_grains.append(GRAIN_VALUE_MAP['PT1H'])
     if 'minute' in time_partitions:
-        partition_grains.append(60)
+        partition_grains.append(GRAIN_VALUE_MAP['PT1M'])
 
     partition_grains.sort()
+    if partition_grains:
+        return partition_grains[0]
 
-    return partition_grains[0]
+    return None
 
 
 

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -80,7 +80,7 @@ def get_hive_partitions(database, datasource_name):
     return table.hive_partitions
 
 def default_hive_query_generator(sql, query_obj, database, datasource_name):
-
+    st_seconds = datetime.now()
     """ schema for time based partition in table
     {
       "time":{
@@ -109,13 +109,9 @@ def default_hive_query_generator(sql, query_obj, database, datasource_name):
                 granularity = query_obj['granularity']
                 granularity_in_partitions = (granularity in time_partitions)
                 if st and en and gran_seconds:
-                    dt = datetime.today()
-                    st_seconds = dt.timestamp()
                     where_clause = get_partitioned_whereclause(st, en, gran_seconds, time_partitions)
                     sql_updated = replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
-                    dt = datetime.today()
-                    ed_seconds = dt.timestamp()
-                    logging.info('[HIVE PARTITION QUERY] query formation time {0} seconds'.format(ed_seconds-st_seconds))
+                    logging.info('[PERFORMANCE CHECK] Hive Partition Query formation time {0} '.format(datetime.now() - st_seconds))
                     return sql_updated
-
+    logging.info('[PERFORMANCE CHECK] Hive Partition Query formation time {0} '.format(datetime.now() - st_seconds))
     return sql

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -14,11 +14,11 @@ GRAN_VALUE_MAP = {
     'P1Y'  : 31556926
 }
 
-# return seconds from gran valaue map
+# return seconds from gran valaue map default is 86400
 def get_gran_value_in_seconds(value):
     if  value in GRAN_VALUE_MAP:
         return GRAN_VALUE_MAP[value]
-    return None
+    return 86400
 
 
 def get_partitioned_query(time_partitions):
@@ -40,6 +40,11 @@ def get_partitioned_whereclause(_st, _en, gran_seconds, time_partitions):
     time_seq = list()
     # consider here only till < condition because hive store data like that
     # ie 10-11 hr data will exist in 10th hr partition
+
+    # handle same st and ed selection case,single point selection
+    if _st == _en:
+        time_seq.append(_st.strftime(get_partitioned_query(time_partitions)))
+
     while _st < _en:
         time_seq.append(_st.strftime(get_partitioned_query(time_partitions)))
         _st = _st + timedelta(seconds=gran_seconds)

--- a/superset/migrations/versions/ed8da0d765e1_add_hive_partition_column_to_sqla_model_.py
+++ b/superset/migrations/versions/ed8da0d765e1_add_hive_partition_column_to_sqla_model_.py
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+"""add_hive_partition_column_to_sqla_model.py
+
+Revision ID: ed8da0d765e1
+Revises: d1385e981f11
+Create Date: 2019-04-03 12:15:23.223445
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ed8da0d765e1'
+down_revision = 'd1385e981f11'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('tables', sa.Column('hive_partitions', sa.Text(), nullable=True))
+
+def downgrade():
+    op.drop_column('tables', 'hive_partitions')

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -851,6 +851,7 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
         with closing(engine.raw_connection()) as conn:
             with closing(conn.cursor()) as cursor:
+                st_seconds = datetime.now()
                 for sql in sqls[:-1]:
                     _log_query(sql)
                     self.db_engine_spec.execute(cursor, sql)
@@ -858,7 +859,10 @@ class Database(Model, AuditMixinNullable, ImportMixin):
 
                 _log_query(sqls[-1])
                 self.db_engine_spec.execute(cursor, sqls[-1])
-
+                
+                logging.info('[PERFORMANCE CHECK] query response time from db {0} '.format(datetime.now()-st_seconds))
+               
+                st_seconds = datetime.now()
                 if cursor.description is not None:
                     columns = [col_desc[0] for col_desc in cursor.description]
                 else:
@@ -873,6 +877,8 @@ class Database(Model, AuditMixinNullable, ImportMixin):
                 for k, v in df.dtypes.items():
                     if v.type == numpy.object_ and needs_conversion(df[k]):
                         df[k] = df[k].apply(utils.json_dumps_w_dates)
+
+                logging.info('[PERFORMANCE CHECK] pandas data frame formation time after response {0} '.format(datetime.now()-st_seconds))        
                 return df
 
     def compile_sqla_query(self, qry, schema=None):

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -276,7 +276,7 @@ class BaseViz(object):
         """Building a query object"""
 
         has_kerberos_ticket()
-        
+        st_seconds = datetime.now()
         form_data = self.form_data
         self.process_query_filters()
         gb = form_data.get('groupby') or []
@@ -343,6 +343,7 @@ class BaseViz(object):
             'prequeries': [],
             'is_prequery': False,
         }
+        logging.info('[PERFORMANCE CHECK] Query Obj formation time {0} '.format(datetime.now() - st_seconds))    
         return d
 
     @property
@@ -388,17 +389,23 @@ class BaseViz(object):
 
     def get_payload(self, query_obj=None):
         """Returns a payload of metadata and data"""
+        st_seconds = datetime.now()
         self.run_extra_queries()
         payload = self.get_df_payload(query_obj)
 
         df = payload.get('df')
+        st_seconds_1 = datetime.now()
         if self.status != utils.QueryStatus.FAILED:
             if df is not None and df.empty:
                 payload['error'] = 'No data'
             else:
                 payload['data'] = self.get_data(df)
+       
+        logging.info('[PERFORMANCE CHECK] df to  for  vis data convertion time {0} '.format(datetime.now() - st_seconds_1))  
+
         if 'df' in payload:
             del payload['df']
+        logging.info('[PERFORMANCE CHECK] Total Time in execute request  and transform  to vis data  {0} '.format(datetime.now()-st_seconds))    
         return payload
 
     def get_df_payload(self, query_obj=None, **kwargs):

--- a/tests/hivequery_tests.py
+++ b/tests/hivequery_tests.py
@@ -1,37 +1,39 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 import unittest
 import datetime
 
 from superset.hive_query import (
     get_gran_value_in_seconds,
-    get_hive_partitions,
-    get_partitioned_query,
+    get_partitioned_query_format,
     get_partitioned_whereclause,
     replace_whereclause_in_org_sql,
-    
 )
 
 class HivePartitionQueryTestCase(unittest.TestCase):
 
     def test_get_gran_value_in_seconds(self):
-        self.assertEqual(get_gran_value_in_seconds('PT1S'),1)
-
-    def test_get_partitioned_query(self):
-        t_p_1 = {
-            "year":"y"
-        }
-        self.assertEqual(get_partitioned_query(t_p_1),"( y = %Y )")
         t_p_2 = {
-            "year":"y",
-            "month":"m"
-        }
-        self.assertEqual(get_partitioned_query(t_p_2),"( y = %Y AND m = %m )")
-
-        t_p_3 = {
             "year":"y",
             "month":"m",
             "day":"d",
         }
-        self.assertEqual(get_partitioned_query(t_p_3),"( y = %Y AND m = %m AND d = %d )")
+        self.assertEqual(get_gran_value_in_seconds('PT1H',t_p_2),86400)
 
         t_p_4 = {
             "year":"y",
@@ -39,7 +41,41 @@ class HivePartitionQueryTestCase(unittest.TestCase):
             "day":"d",
             "hour":"hr"
         }
-        self.assertEqual(get_partitioned_query(t_p_4),"( y = %Y AND m = %m AND d = %d AND hr = %H )")
+        self.assertEqual(get_gran_value_in_seconds('PT1H',t_p_4),3600)
+
+        t_p_5 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+            "hour":"hr",
+        }
+        self.assertEqual(get_gran_value_in_seconds('P1D',t_p_5),86400)
+
+    def test_get_partitioned_query_format(self):
+        t_p_1 = {
+            "year":"y"
+        }
+        self.assertEqual(get_partitioned_query_format(t_p_1),"( y = %Y )")
+        t_p_2 = {
+            "year":"y",
+            "month":"m"
+        }
+        self.assertEqual(get_partitioned_query_format(t_p_2),"( y = %Y AND m = %m )")
+
+        t_p_3 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+        }
+        self.assertEqual(get_partitioned_query_format(t_p_3),"( y = %Y AND m = %m AND d = %d )")
+
+        t_p_4 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+            "hour":"hr"
+        }
+        self.assertEqual(get_partitioned_query_format(t_p_4),"( y = %Y AND m = %m AND d = %d AND hr = %H )")
 
         t_p_5 = {
             "year":"y",
@@ -48,21 +84,26 @@ class HivePartitionQueryTestCase(unittest.TestCase):
             "hour":"hr",
             "minute":"min"
         }
-        self.assertEqual(get_partitioned_query(t_p_5),"( y = %Y AND m = %m AND d = %d AND hr = %H AND min = %M )")
+        self.assertEqual(get_partitioned_query_format(t_p_5),"( y = %Y AND m = %m AND d = %d AND hr = %H AND min = %M )")
+        t_p_6 = {
+            "month":"m",
+            "day":"d",
+            "hour":"hr",
+        }
+        self.assertEqual(get_partitioned_query_format(t_p_6),"( m = %m AND d = %d AND hr = %H )")
 
     def test_get_partitioned_whereclause(self):
         from_date_time_str = '2019-01-01 10:00:00'
         from_date_time_obj = datetime.datetime.strptime(from_date_time_str, '%Y-%m-%d %H:%M:%S')   
         to_date_time_str = '2019-01-01 11:00:00'
         to_date_time_obj = datetime.datetime.strptime(to_date_time_str, '%Y-%m-%d %H:%M:%S') 
-        grain =  get_gran_value_in_seconds('PT1H')
-
         t_p_5 = {
             "year":"y",
             "month":"m",
             "day":"d",
             "hour":"hr",
         }
+        grain =  get_gran_value_in_seconds('PT1H',t_p_5)
         updated_sql = "( y = 2019 AND m = 01 AND d = 01 AND hr = 10 )" 
         self.assertEqual(get_partitioned_whereclause(from_date_time_obj,to_date_time_obj,grain,t_p_5),updated_sql)
 

--- a/tests/hivequery_tests.py
+++ b/tests/hivequery_tests.py
@@ -1,0 +1,81 @@
+import unittest
+import datetime
+
+from superset.hive_query import (
+    get_gran_value_in_seconds,
+    get_hive_partitions,
+    get_partitioned_query,
+    get_partitioned_whereclause,
+    replace_whereclause_in_org_sql,
+    
+)
+
+class HivePartitionQueryTestCase(unittest.TestCase):
+
+    def test_get_gran_value_in_seconds(self):
+        self.assertEqual(get_gran_value_in_seconds('PT1S'),1)
+
+    def test_get_partitioned_query(self):
+        t_p_1 = {
+            "year":"y"
+        }
+        self.assertEqual(get_partitioned_query(t_p_1),"( y = %Y )")
+        t_p_2 = {
+            "year":"y",
+            "month":"m"
+        }
+        self.assertEqual(get_partitioned_query(t_p_2),"( y = %Y AND m = %m )")
+
+        t_p_3 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+        }
+        self.assertEqual(get_partitioned_query(t_p_3),"( y = %Y AND m = %m AND d = %d )")
+
+        t_p_4 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+            "hour":"hr"
+        }
+        self.assertEqual(get_partitioned_query(t_p_4),"( y = %Y AND m = %m AND d = %d AND hr = %H )")
+
+        t_p_5 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+            "hour":"hr",
+            "minute":"min"
+        }
+        self.assertEqual(get_partitioned_query(t_p_5),"( y = %Y AND m = %m AND d = %d AND hr = %H AND min = %M )")
+
+    def test_get_partitioned_whereclause(self):
+        from_date_time_str = '2019-01-01 10:00:00'
+        from_date_time_obj = datetime.datetime.strptime(from_date_time_str, '%Y-%m-%d %H:%M:%S')   
+        to_date_time_str = '2019-01-01 11:00:00'
+        to_date_time_obj = datetime.datetime.strptime(to_date_time_str, '%Y-%m-%d %H:%M:%S') 
+        grain =  get_gran_value_in_seconds('PT1H')
+
+        t_p_5 = {
+            "year":"y",
+            "month":"m",
+            "day":"d",
+            "hour":"hr",
+        }
+        updated_sql = "( y = 2019 AND m = 01 AND d = 01 AND hr = 10 )" 
+        self.assertEqual(get_partitioned_whereclause(from_date_time_obj,to_date_time_obj,grain,t_p_5),updated_sql)
+
+    def test_replace_whereclause_in_org_sql(self):
+        granularity = 'timestamp'
+        sql = "WHERE `timestamp` >= '20190411000000' AND `timestamp` <= '20190412000000' AND `c_call_completed` >= 2"
+        where_clause = "( y = 2019 AND m = 01 AND d = 01 AND hr = 10 )" 
+        response = " WHERE ( y = 2019 AND m = 01 AND d = 01 AND hr = 10 ) AND  `timestamp` >= '20190411000000' AND `timestamp` <= '20190412000000' AND `c_call_completed` >= 2"
+        self.assertEqual(replace_whereclause_in_org_sql(granularity, sql, where_clause, False),response)
+
+        sql = "WHERE `timestamp` >= 20190411000000 AND `timestamp` <= 20190412000000 AND `c_call_completed` >= 2"
+        response_1 = "WHERE ( y = 2019 AND m = 01 AND d = 01 AND hr = 10 ) \n AND `c_call_completed` >= 2"
+        self.assertEqual(replace_whereclause_in_org_sql(granularity, sql, where_clause, True),response_1)
+
+
+


### PR DESCRIPTION

**Scope**: 
1.Partition support is implemented for time based partition only but configuration can be save for any type of partition
2. Hive bucketing based  config and query transformation is not supported
3. Timerange selection and grain selection will be same as superset behaviour


**Assumption**:
 1. To generate time based query ,Configure atleast  one  column of  Hive DB Tables (used ad datasource in visualisation/filter-box)  with Is temporal value as True and Date-time Format is epoch_s or epoch_ms .

2. Use #1 column as DateTime Column in Filter Box or any Visualisation's Time Filter Section .  
3.Select Time Grain from Time Section  to set interval like day/hour/minute to create buckets for selected time-range
4. Non time based partitions will be supported by default superset Filters behaviour and for this configure partition at table level is not required


**Design** :
1.add support of  hive-partition config parameter at Database Table Configuration
2.Config structure is JSON object  like
{
"year":"_hive_year_col",
"month":"_hive_month_col",
"day":"_hive_day_col",
"hour":"_hive_hour_col",
"minute":"_hive_minute_col",
}

3.Set above structure as per partition supported by table
4.Replace `epoche` >= 1544317200.0 AND `epoche` <= 1544317200.0 type of where clause from SQL query via partition base query like -
( year = 2018 AND month = 12 AND day = 09 AND hour = 01 AND minute = 00 )
OR
( year = 2018 AND month = 12 AND day = 09 AND hour = 02 AND minute = 00 )
....


5.There is no date time rounding in case of mismatch in grain 
6.Query is formed till  partitions ,rest values will be skipped .
7. Difference between two time point is as per selected grain 





 