### PR TITLE
fix(table-query-restriction): restrict first time table query call when user creates a new table

### DIFF
--- a/superset/assets/src/explore/controlPanels/Table.js
+++ b/superset/assets/src/explore/controlPanels/Table.js
@@ -62,7 +62,7 @@ export default {
   ],
   controlOverrides: {
     metrics: {
-      // validators: [],
+       validators: [],
     },
   },
 };


### PR DESCRIPTION
restrict first time table query call when user creates a new table

removed default validation of Metrics to allow "Not Group By" call

UIC-1174