### PR TITLE
#[UIC-1213] Geomap (based on leaflet) is coming on the top of every RVF component

### DIFF
--- a/superset/assets/src/visualizations/LeafletMap/LeafletMap.js
+++ b/superset/assets/src/visualizations/LeafletMap/LeafletMap.js
@@ -33,7 +33,7 @@ function LeafletMap(element, props) {
     const MARKER_WEIGHT = 1;
     const MARKER_OPACITY = 1;
     const LEAFLET_VIS_ID = 'leafllet-chart-id';
-    const MAP_CONTAINER = '<div id = ' + LEAFLET_VIS_ID + ' style="width: 100%; height: 100%;"></div>';
+    const MAP_CONTAINER = '<div id = ' + LEAFLET_VIS_ID + ' style="width: 100%; height: 100%;z-index:0;"></div>';
     var colorCols;
     var geoJson;
     var mapInstance;


### PR DESCRIPTION
1. When we want to edit a dashboard with leaflet map on top-right corner, then 'edit dashboard' options are coming behind leaf let map
2. We are not getting loading icon at Leaf Let Map in explore mode
3. When we scroll a dashboard with Map Visualisation on top row, then dashboard title is shadowed by the map