### PR TITLE
#[UIC-1130] fix Dashboard should be imported without modifying id

### DIFF
--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -24,7 +24,7 @@ import json
 import logging
 import textwrap
 
-from flask import escape, g, Markup, request
+from flask import escape, g, Markup, request, flash
 from flask_appbuilder import Model
 from flask_appbuilder.models.decorators import renders
 from flask_appbuilder.security.sqla.models import User
@@ -562,12 +562,20 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
 
         # override the dashboard
         existing_dashboard = None
-        # for dash in session.query(Dashboard).all():
-        #     if ('remote_id' in dash.params_dict and
-        #             dash.params_dict['remote_id'] ==
-        #             dashboard_to_import.id):
-        #         existing_dashboard = dash
-
+        existing_slug = None  
+        for dash in session.query(Dashboard).all():
+            # if ('remote_id' in dash.params_dict and
+            #         dash.params_dict['remote_id'] ==
+            #         dashboard_to_import.id):
+            #     existing_dashboard = dash
+            if (dash.slug == dashboard_to_import.slug):
+                existing_slug = True
+                logging.info('Dashboard with same slug exists. Dashboard id {} Dashboard title: {}'.format(
+                    dash.id, dash.dashboard_title))
+        if existing_slug:
+            flash(u'Dashboard with same slug exists. Update the slug and reimport', 'danger')
+            session.rollback()
+            return None
         dashboard_to_import.id = None
         if dashboard_to_import.position_json is not None:
             alter_positions(dashboard_to_import, old_to_new_slc_id_dict)

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -562,11 +562,11 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
 
         # override the dashboard
         existing_dashboard = None
-        for dash in session.query(Dashboard).all():
-            if ('remote_id' in dash.params_dict and
-                    dash.params_dict['remote_id'] ==
-                    dashboard_to_import.id):
-                existing_dashboard = dash
+        # for dash in session.query(Dashboard).all():
+        #     if ('remote_id' in dash.params_dict and
+        #             dash.params_dict['remote_id'] ==
+        #             dashboard_to_import.id):
+        #         existing_dashboard = dash
 
         dashboard_to_import.id = None
         if dashboard_to_import.position_json is not None:


### PR DESCRIPTION
When user imports a dashboard, it should always create a new dashboard with auto-incremented id.