### PR TITLE
#[UIC-1184]: Used hive supported functions instead of date_trunc for time gran

### DIFF
--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1063,20 +1063,16 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     time_grain_functions = {
         None: '{col}',
-        'PT1S': "second(CAST({col} AS TIMESTAMP))",
-        'PT1M': "minute(CAST({col} AS TIMESTAMP))",
-        'PT1H': "hour(CAST({col} AS TIMESTAMP))",
-        'P1D': "day( CAST({col} AS TIMESTAMP))",
-        'P1W': "weekofyear(CAST({col} AS TIMESTAMP))",
-        'P1M': "month(CAST({col} AS TIMESTAMP))",
-        'P0.25Y': "date_trunc('quarter', CAST({col} AS TIMESTAMP))",
-        'P1Y': "year CAST({col} AS TIMESTAMP))",
-        'P1W/1970-01-03T00:00:00Z':
-            "date_add('day', 5, weekofyear(date_add('day', 1, \
-            CAST({col} AS TIMESTAMP))))",
+        'PT1S': "from_unixtime({col}, 'yyyy-MM-dd HH:mm:ss')",
+        'PT1M': "from_unixtime({col}, 'yyyy-MM-dd HH:mm')",
+        'PT1H': "from_unixtime({col}, 'yyyy-MM-dd HH')",
+        'P1D': "from_unixtime({col}, 'yyyy-MM-dd')",
+        'P1W': "date_sub(next_day(from_unixtime({col}, 'yyyy-MM-dd'), 'MON'), 7)",
+        'P1M': "from_unixtime({col}, 'yyyy-MM')",
+        'P0.25Y': "add_months(trunc(from_unixtime({col}), 'MM'), -(month(from_unixtime({col}))-1)%3)",
+        'P1Y': "from_unixtime({col}, 'yyyy')",
         '1969-12-28T00:00:00Z/P1W':
-            "date_add('day', -1, weekofyear( \
-            date_add('day', 1, CAST({col} AS TIMESTAMP))))",
+            "date_sub(next_day(from_unixtime({col}, 'yyyy-MM-dd'), 'SUN'), 7)",
     }
 
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1063,16 +1063,16 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     time_grain_functions = {
         None: '{col}',
-        'PT1S': "from_unixtime({col}, 'yyyy-MM-dd HH:mm:ss')",
-        'PT1M': "from_unixtime({col}, 'yyyy-MM-dd HH:mm')",
-        'PT1H': "from_unixtime({col}, 'yyyy-MM-dd HH')",
-        'P1D': "from_unixtime({col}, 'yyyy-MM-dd')",
-        'P1W': "date_sub(next_day(from_unixtime({col}, 'yyyy-MM-dd'), 'MON'), 7)",
-        'P1M': "from_unixtime({col}, 'yyyy-MM')",
-        'P0.25Y': "add_months(trunc(from_unixtime({col}), 'MM'), -(month(from_unixtime({col}))-1)%3)",
-        'P1Y': "from_unixtime({col}, 'yyyy')",
+        'PT1S': "from_unixtime((unix_timestamp({col}), 'yyyy-MM-dd HH:mm:ss')",
+        'PT1M': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd HH:mm')",
+        'PT1H': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd HH')",
+        'P1D': "from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd')",
+        'P1W': "date_sub(next_day(from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd'), 'MON'), 7)",
+        'P1M': "from_unixtime(unix_timestamp({col}), 'yyyy-MM')",
+        'P0.25Y': "add_months(trunc(from_unixtime(unix_timestamp({col})), 'MM'), -(month(from_unixtime(unix_timestamp({col})))-1)%3)",
+        'P1Y': "from_unixtime(unix_timestamp({col}), 'yyyy')",
         '1969-12-28T00:00:00Z/P1W':
-            "date_sub(next_day(from_unixtime({col}, 'yyyy-MM-dd'), 'SUN'), 7)",
+            "date_sub(next_day(from_unixtime(unix_timestamp({col}), 'yyyy-MM-dd'), 'SUN'), 7)",
     }
 
 

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -1061,6 +1061,25 @@ class HiveEngineSpec(PrestoEngineSpec):
 
     engine = 'hive'
 
+    time_grain_functions = {
+        None: '{col}',
+        'PT1S': "second(CAST({col} AS TIMESTAMP))",
+        'PT1M': "minute(CAST({col} AS TIMESTAMP))",
+        'PT1H': "hour(CAST({col} AS TIMESTAMP))",
+        'P1D': "day( CAST({col} AS TIMESTAMP))",
+        'P1W': "weekofyear(CAST({col} AS TIMESTAMP))",
+        'P1M': "month(CAST({col} AS TIMESTAMP))",
+        'P0.25Y': "date_trunc('quarter', CAST({col} AS TIMESTAMP))",
+        'P1Y': "year CAST({col} AS TIMESTAMP))",
+        'P1W/1970-01-03T00:00:00Z':
+            "date_add('day', 5, weekofyear(date_add('day', 1, \
+            CAST({col} AS TIMESTAMP))))",
+        '1969-12-28T00:00:00Z/P1W':
+            "date_add('day', -1, weekofyear( \
+            date_add('day', 1, CAST({col} AS TIMESTAMP))))",
+    }
+
+
     # Scoping regex at class level to avoid recompiling
     # 17/02/07 19:36:38 INFO ql.Driver: Total jobs = 5
     jobs_stats_r = re.compile(
@@ -1367,7 +1386,7 @@ class HiveEngineSpec(PrestoEngineSpec):
                                 f' differs from {labels_expected}')
             else:
                 df.columns = labels_expected
-                
+
     @staticmethod
     def execute(cursor, query, async_=False):
         kwargs = {'async': async_}


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Update time gran functions to use hive supported functions

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@bipinsoniguavus @arpit-agarwal 

### BUG ID
UIC-1184