### PR TITLE
#UIC-1135 Shareable url for charts/dashboard should work behind nginx proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,4 @@ celerybeat.pid
 geckodriver.log
 ghostdriver.log
 testCSV.csv
+cypress

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ geckodriver.log
 ghostdriver.log
 testCSV.csv
 cypress
+superset/assets/output

--- a/superset/assets/spec/javascripts/components/URLShortLinkButton_spec.jsx
+++ b/superset/assets/spec/javascripts/components/URLShortLinkButton_spec.jsx
@@ -26,6 +26,7 @@ import URLShortLinkButton from '../../../src/components/URLShortLinkButton';
 describe('URLShortLinkButton', () => {
   const defaultProps = {
     url: 'mockURL',
+    origin: 'http://mock-remote/',
     emailSubject: 'Mock Subject',
     emailContent: 'mock content',
   };
@@ -40,4 +41,11 @@ describe('URLShortLinkButton', () => {
     const wrapper = setup();
     expect(wrapper.find(OverlayTrigger)).toHaveLength(1);
   });
+
+  it('prepend origin to short-url', () => {
+    const wrapper = setup();
+    const inst = wrapper.instance();
+    inst.onShortUrlSuccess('/my-mock-url');
+    expect(wrapper.state().shortUrl).toEqual(defaultProps.origin+'/my-mock-url');
+  })
 });

--- a/superset/assets/spec/javascripts/components/URLShortLinkModal_spec.jsx
+++ b/superset/assets/spec/javascripts/components/URLShortLinkModal_spec.jsx
@@ -26,6 +26,7 @@ import ModalTrigger from '../../../src/components/ModalTrigger';
 describe('URLShortLinkModal', () => {
   const defaultProps = {
     url: 'mockURL',
+    origin: 'http://mock-remote/',
     emailSubject: 'Mock Subject',
     emailContent: 'mock content',
   };
@@ -40,4 +41,11 @@ describe('URLShortLinkModal', () => {
     const wrapper = setup();
     expect(wrapper.find(ModalTrigger)).toHaveLength(1);
   });
+
+  it('prepend origin to short-url', () => {
+    const wrapper = setup();
+    const inst = wrapper.instance();
+    inst.onShortUrlSuccess('/my-mock-url');
+    expect(wrapper.state().shortUrl).toEqual(defaultProps.origin+'/my-mock-url');
+  })
 });

--- a/superset/assets/src/components/URLShortLinkButton.jsx
+++ b/superset/assets/src/components/URLShortLinkButton.jsx
@@ -26,6 +26,7 @@ import withToasts from '../messageToasts/enhancers/withToasts';
 
 const propTypes = {
   url: PropTypes.string,
+  origin: PropTypes.string,
   emailSubject: PropTypes.string,
   emailContent: PropTypes.string,
   addDangerToast: PropTypes.func.isRequired,
@@ -42,9 +43,11 @@ class URLShortLinkButton extends React.Component {
   }
 
   onShortUrlSuccess(shortUrl) {
-    this.setState(() => ({
-      shortUrl,
-    }));
+    this.setState(() => {
+      const baseUrl = this.props.origin;
+      const url = `${baseUrl}${shortUrl}`;
+      return { 'shortUrl': url }
+    });
   }
 
   getCopyUrl() {
@@ -87,6 +90,7 @@ class URLShortLinkButton extends React.Component {
 
 URLShortLinkButton.defaultProps = {
   url: window.location.href.substring(window.location.origin.length),
+  origin: window.location.origin,
   emailSubject: '',
   emailContent: '',
 };

--- a/superset/assets/src/components/URLShortLinkModal.jsx
+++ b/superset/assets/src/components/URLShortLinkModal.jsx
@@ -26,6 +26,7 @@ import ModalTrigger from './ModalTrigger';
 
 const propTypes = {
   url: PropTypes.string,
+  origin: PropTypes.string,
   emailSubject: PropTypes.string,
   emailContent: PropTypes.string,
   addDangerToast: PropTypes.func.isRequired,
@@ -46,7 +47,11 @@ class URLShortLinkModal extends React.Component {
   }
 
   onShortUrlSuccess(shortUrl) {
-    this.setState(() => ({ shortUrl }));
+    this.setState(() => {
+      const baseUrl = this.props.origin;
+      const url = `${baseUrl}${shortUrl}`;
+      return { 'shortUrl': url }
+    });
   }
 
   setModalRef(ref) {
@@ -85,6 +90,7 @@ class URLShortLinkModal extends React.Component {
 
 URLShortLinkModal.defaultProps = {
   url: window.location.href.substring(window.location.origin.length),
+  origin: window.location.origin,
   emailSubject: '',
   emailContent: '',
 };

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -804,8 +804,7 @@ class R(BaseSupersetView):
         db.session.add(obj)
         db.session.commit()
         return Response(
-            '{scheme}://{request.headers[Host]}/r/{obj.id}'.format(
-                scheme=request.scheme, request=request, obj=obj),
+            '/r/{obj.id}'.format(obj=obj),
             mimetype='text/plain')
 
 


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [x] Add tests
- [ ] Build / Development Environment
- [ ] Documentation
- [x] PR Build

### SUMMARY
We want to ensure sharable url given from RVF is usable. Currently the sharable url point to request between nginx and RVF rather that based on client request.

We has 3 choices for implementation and we have chosen the last one

1.  Update nginx configuration to ensure `request` passed to gUnicorn has right param to ensure url get formed correctly
1. Introduce `BASE_DOMAIN` in config.py and use that to generate the urk
1. We should return relative url from backend `shortner` API and prepend `location.origin` at frontend

We have spent some time to pursue 1 but decided against it due to repeat work required for other proxy server if used and complexity

We have discarded 2 in interest of time and complexity

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Once a docker is available i will add after snapshot
Before:
<img width="1124" alt="before" src="https://user-images.githubusercontent.com/13412230/56799829-529cab80-6837-11e9-99aa-6d478985236a.png">

### TEST PLAN
We should deploy the RVF behind nginx on a server. Our docker build should be fine
test shared-url at charts and dashboard level
### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@jitendra-kumawat 