### PR TITLE
#[UIC-1244]:add support to on off hive partition query at Vis level

### DIFF
--- a/superset/assets/src/explore/controlPanels/sections.jsx
+++ b/superset/assets/src/explore/controlPanels/sections.jsx
@@ -61,7 +61,7 @@ export const sqlaTimeSeries = {
   expanded: true,
   controlSetRows: [
     ['granularity_sqla', 'time_grain_sqla'],
-    ['time_range'],
+    ['time_range','query_with_partitions'],
   ],
 };
 

--- a/superset/assets/src/explore/controlPanels/sections.jsx
+++ b/superset/assets/src/explore/controlPanels/sections.jsx
@@ -61,7 +61,8 @@ export const sqlaTimeSeries = {
   expanded: true,
   controlSetRows: [
     ['granularity_sqla', 'time_grain_sqla'],
-    ['time_range','query_with_partitions'],
+    ['time_range'],
+    ['query_with_partitions'],
   ],
 };
 

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -235,6 +235,20 @@ export const controls = {
     }),
   },
 
+  query_with_partitions: {
+    type: 'CheckboxControl',
+    label: t('Query with Partitions'),
+    default: true,
+    renderTrigger: false,
+    description: t('Use this flag to convert time range based '+
+    'WHERE Clause Query to Hive Time based partition Query.'+
+    'For this Hive Partitions must be configured at Datasource.'),
+    mapStateToProps: state => ({
+      hidden: (state.datasource.database.backend == "hive") ? false : true,
+      default: (state.datasource.database.backend == "hive") ? true : false,
+    }),
+  },
+
   viz_type: {
     type: 'VizTypeControl',
     label: t('Visualization Type'),

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -241,8 +241,8 @@ export const controls = {
     default: true,
     renderTrigger: false,
     description: t('Use this flag to convert time range based '+
-    'WHERE Clause Query to Hive Time based partition Query.'+
-    'For this Hive Partitions must be configured at Datasource.'),
+    'WHERE clause query to hive time based partition query. '+
+    'For this, hive partitions must be configured at datasource.'),
     mapStateToProps: state => ({
       hidden: (state.datasource.database.backend == "hive") ? false : true,
       default: (state.datasource.database.backend == "hive") ? true : false,

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -133,7 +133,7 @@ def default_hive_query_generator(sql, query_obj, database, datasource_name):
      where clause from sql to specific partition based  where clause
      and returning update sql
     """
-    if database.backend == 'hive':
+    if database.backend == 'hive' and query_obj['extras']['query_with_partitions']:
         hive_partitions = get_hive_partitions(database, datasource_name)
         if hive_partitions:
             hive_partitions_obj = json.loads(hive_partitions)

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -325,6 +325,7 @@ class BaseViz(object):
             'having_druid': form_data.get('having_filters', []),
             'time_grain_sqla': form_data.get('time_grain_sqla', ''),
             'druid_time_origin': form_data.get('druid_time_origin', ''),
+            'query_with_partitions':form_data.get('query_with_partitions',False)
         }
 
         d = {


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
add support to on off hive partition query at Vis level

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
BEFORE or Non Hive Datasources
<img width="569" alt="Screenshot 2019-05-03 at 10 00 45 AM" src="https://user-images.githubusercontent.com/13414728/57119784-65106b00-6d8a-11e9-981e-4e209d826494.png">


AFTER or only for Hive Datasources
<img width="866" alt="Screenshot 2019-05-03 at 12 27 13 PM" src="https://user-images.githubusercontent.com/13414728/57123422-6730f480-6d9f-11e9-9856-fd4c9ae52a10.png">



### TEST PLAN
1. define hive partitions at table level
2. define time column and select time range
3. validate queries formed in view query modal on check/uncheck of Query with Partitions option
4. Query with Partitions option is available only for hive datasources
5. validate  correct query  formed  via options available in explore mode 

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
