### PR TITLE
#[UIC-1310] BigNumberTotal Chart with two metrics field support | Absolute and Percentage

### DIFF
--- a/superset/assets/src/explore/controlPanels/BigNumberTotal.js
+++ b/superset/assets/src/explore/controlPanels/BigNumberTotal.js
@@ -35,12 +35,16 @@ export default {
       controlSetRows: [
         ['subheader'],
         ['y_axis_format'],
+        ['percentage_format'],
       ],
     },
   ],
   controlOverrides: {
     y_axis_format: {
       label: t('Number format'),
+    },
+    percentage_format: {
+      label: t('Percent format'),
     },
   },
 };

--- a/superset/assets/src/explore/controlPanels/BigNumberTotal.js
+++ b/superset/assets/src/explore/controlPanels/BigNumberTotal.js
@@ -25,6 +25,7 @@ export default {
       expanded: true,
       controlSetRows: [
         ['metric'],
+        ['percentageMetric'],
         ['adhoc_filters'],
       ],
     },

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -147,6 +147,25 @@ const groupByControl = {
   commaChoosesOption: false,
 };
 
+const percentageMetric = {
+  type: 'MetricsControl',
+  multi: false,
+  label: t('Percentage Metric'),
+  validators: [],
+  mapStateToProps: (state) => {
+    const datasource = state.datasource;
+    return {
+      columns: datasource ? datasource.columns : [],
+      savedMetrics: datasource ? datasource.metrics : [],
+      datasourceType: datasource && datasource.type,
+    };
+  },
+  description: t('Metric for percentage values to be displayed'),
+  default: props => {
+    return null;
+  },
+};
+
 const metrics = {
   type: 'MetricsControl',
   multi: true,
@@ -165,6 +184,7 @@ const metrics = {
   },
   description: t('One or many metrics to display'),
 };
+
 const metric = {
   ...metrics,
   multi: false,
@@ -223,6 +243,8 @@ export const controls = {
   metrics,
 
   metric,
+
+  percentageMetric,
 
   datasource: {
     type: 'DatasourceControl',

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -89,6 +89,11 @@ const D3_FORMAT_OPTIONS = [
   ['$,.2f', '$,.2f (12345.432 => $12,345.43)'],
 ];
 
+const D3_PERCENT_FORMAT_OPTIONS = [
+  [',.1%', ',.1% (12345.432 => 1,234,543.2%)'],
+  ['.3%', '.3% (12345.432 => 1234543.200%)'],
+];
+
 const ROW_LIMIT_OPTIONS = [10, 50, 100, 250, 500, 1000, 5000, 10000, 50000];
 
 const SERIES_LIMITS = [0, 5, 10, 25, 50, 100, 500];
@@ -1325,6 +1330,16 @@ export const controls = {
     default: '.3s',
     choices: D3_FORMAT_OPTIONS,
     description: D3_FORMAT_DOCS,
+  },
+
+  percentage_format: {
+    type: 'SelectControl',
+    freeForm: true,
+    renderTrigger: true,
+    default: ',.1%',
+    label: t('Percent Format'),
+    choices: D3_PERCENT_FORMAT_OPTIONS,
+    description: t('Only applicable on Percentage Metric'),
   },
 
   date_time_format: {

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.css
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.css
@@ -45,6 +45,7 @@
 .big_number .bn_layout {
   display: flex;
   justify-content: space-between;
+  align-items: center;
 }
 
 .big_number .header_line span {

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.css
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.css
@@ -42,6 +42,11 @@
   font-weight: 600;
 }
 
+.big_number .bn_layout {
+  display: flex;
+  justify-content: space-between;
+}
+
 .big_number .header_line span {
   position: absolute;
   bottom: 0;

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
@@ -131,7 +131,7 @@ class BigNumberVis extends React.PureComponent {
     document.body.removeChild(container);
 
     // Using percentage_text variable to show percentage number
-    if (bigNumberPercentage != undefined && bigNumberPercentage >= 0) {
+    if (bigNumberPercentage != undefined) {
       const fontSize = computeMaxFontSize({
         text,
         maxWidth: Math.floor(width/2),

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
@@ -66,6 +66,7 @@ const propTypes = {
   width: PropTypes.number.isRequired,
   height: PropTypes.number.isRequired,
   bigNumber: PropTypes.number.isRequired,
+  bigNumberPercentage: PropTypes.number.isRequired,
   formatBigNumber: PropTypes.func,
   subheader: PropTypes.string,
   showTrendLine: PropTypes.bool,
@@ -108,12 +109,15 @@ class BigNumberVis extends React.PureComponent {
     return container;
   }
 
-  renderHeader(maxHeight) {
-    const { bigNumber, formatBigNumber, width } = this.props;
+  renderHeader(maxHeight, isTrendLineVisible = false) {
+    const { bigNumber, bigNumberPercentage, formatBigNumber, width } = this.props;
+    // Using text variable to show absolute number
     const text = formatBigNumber(bigNumber);
 
     const container = this.createTemporaryContainer();
     document.body.appendChild(container);
+
+    // Keeping font size for both absolute and percentage numbers will be same.
     const fontSize = computeMaxFontSize({
       text,
       maxWidth: Math.floor(width),
@@ -121,22 +125,44 @@ class BigNumberVis extends React.PureComponent {
       className: 'header_line',
       container,
     });
+
     document.body.removeChild(container);
 
-    return (
-      <div
-        className="header_line"
-        style={{
-          fontSize,
-          height: maxHeight,
-        }}
-      >
-        <span>{text}</span>
-      </div>
-    );
+    // Using percentage_text variable to show percentage number
+    if (bigNumberPercentage) {
+      const percentage_text = bigNumberPercentage;
+
+      return (
+        <div
+          className="header_line bn_layout"
+          style={{
+            fontSize,
+            height: maxHeight,
+          }}
+        >
+          <div>{text}</div>
+          <div>{percentage_text}</div>
+        </div>
+      );
+    }
+    else {
+      return (
+        <div
+          className="header_line"
+          style={{
+            fontSize,
+            height: maxHeight,
+          }}
+        >
+          <div>{text}</div>
+        </div>
+      );
+    }
   }
 
   renderSubheader(maxHeight) {
+    // Relative to addition of one more field as percentage, 
+    // not adding another sub header.
     const { subheader, width } = this.props;
     let fontSize = 0;
     if (subheader) {
@@ -223,7 +249,7 @@ class BigNumberVis extends React.PureComponent {
             className="text_container"
             style={{ height: allTextHeight }}
           >
-            {this.renderHeader(Math.ceil(PROPORTION.HEADER_WITH_TRENDLINE * height))}
+            {this.renderHeader(Math.ceil(PROPORTION.HEADER_WITH_TRENDLINE * height), showTrendLine)}
             {this.renderSubheader(Math.ceil(PROPORTION.SUBHEADER_WITH_TRENDLINE * height))}
           </div>
           {this.renderTrendline(chartHeight)}

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
@@ -111,7 +111,7 @@ class BigNumberVis extends React.PureComponent {
     return container;
   }
 
-  renderHeader(maxHeight, isTrendLineVisible = false) {
+  renderHeader(maxHeight) {
     const { bigNumber, bigNumberPercentage, formatBigNumber, formatPercentage, width } = this.props;
     // Using text variable to show absolute number
     const text = formatBigNumber(bigNumber);
@@ -259,7 +259,7 @@ class BigNumberVis extends React.PureComponent {
             className="text_container"
             style={{ height: allTextHeight }}
           >
-            {this.renderHeader(Math.ceil(PROPORTION.HEADER_WITH_TRENDLINE * height), showTrendLine)}
+            {this.renderHeader(Math.ceil(PROPORTION.HEADER_WITH_TRENDLINE * height))}
             {this.renderSubheader(Math.ceil(PROPORTION.SUBHEADER_WITH_TRENDLINE * height))}
           </div>
           {this.renderTrendline(chartHeight)}

--- a/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
+++ b/superset/assets/src/visualizations/BigNumber/BigNumber.jsx
@@ -68,6 +68,7 @@ const propTypes = {
   bigNumber: PropTypes.number.isRequired,
   bigNumberPercentage: PropTypes.number.isRequired,
   formatBigNumber: PropTypes.func,
+  formatPercentage: PropTypes.func,
   subheader: PropTypes.string,
   showTrendLine: PropTypes.bool,
   startYAxisAtZero: PropTypes.bool,
@@ -78,6 +79,7 @@ const propTypes = {
 const defaultProps = {
   className: '',
   formatBigNumber: identity,
+  formatPercentage: identity,
   subheader: '',
   showTrendLine: false,
   startYAxisAtZero: true,
@@ -110,7 +112,7 @@ class BigNumberVis extends React.PureComponent {
   }
 
   renderHeader(maxHeight, isTrendLineVisible = false) {
-    const { bigNumber, bigNumberPercentage, formatBigNumber, width } = this.props;
+    const { bigNumber, bigNumberPercentage, formatBigNumber, formatPercentage, width } = this.props;
     // Using text variable to show absolute number
     const text = formatBigNumber(bigNumber);
 
@@ -121,7 +123,7 @@ class BigNumberVis extends React.PureComponent {
     const fontSize = computeMaxFontSize({
       text,
       maxWidth: Math.floor(width),
-      maxHeight,
+      maxHeight: maxHeight,
       className: 'header_line',
       container,
     });
@@ -129,8 +131,16 @@ class BigNumberVis extends React.PureComponent {
     document.body.removeChild(container);
 
     // Using percentage_text variable to show percentage number
-    if (bigNumberPercentage) {
-      const percentage_text = bigNumberPercentage;
+    if (bigNumberPercentage != undefined && bigNumberPercentage >= 0) {
+      const fontSize = computeMaxFontSize({
+        text,
+        maxWidth: Math.floor(width/2),
+        maxHeight: maxHeight/2,
+        className: 'header_line',
+        container,
+      });
+
+      const percentage_text = formatPercentage(bigNumberPercentage);
 
       return (
         <div

--- a/superset/assets/src/visualizations/BigNumber/transformProps.js
+++ b/superset/assets/src/visualizations/BigNumber/transformProps.js
@@ -35,6 +35,7 @@ export default function transformProps(chartProps) {
     subheader = '',
     vizType,
     yAxisFormat,
+    percentageFormat,
   } = formData;
   const { data } = payload;
 
@@ -73,13 +74,9 @@ export default function transformProps(chartProps) {
       : null;
   } else {
     bigNumber = data[0][metricName];
-
-    if(percentageMetricName && data[0][percentageMetricName] >= 0) {
-      bigNumberPercentage = data[0][percentageMetricName] + '%';
-      // Uncomment the following code if we want to show the percent value with precisions.
-
-      //const formatPercentChange = getNumberFormatter(NumberFormats.PERCENT)
-      // formattedBigNumberPercentage = `${formatPercentChange(bigNumberPercentage)} %`;
+    
+    if(percentageMetricName && data[0].hasOwnProperty(percentageMetricName)) {
+      bigNumberPercentage = data[0][percentageMetricName];
     }
     
     trendLineData = null;
@@ -93,6 +90,7 @@ export default function transformProps(chartProps) {
   }
 
   const formatValue = getNumberFormatter(yAxisFormat);
+  const percentageFormatValue = getNumberFormatter(percentageFormat);
 
   return {
     width,
@@ -101,6 +99,7 @@ export default function transformProps(chartProps) {
     bigNumberPercentage,
     className,
     formatBigNumber: formatValue,
+    formatPercentage: percentageFormatValue,
     mainColor,
     renderTooltip: renderTooltipFactory(formatValue),
     showTrendLine: supportAndShowTrendLine,

--- a/superset/assets/src/visualizations/BigNumber/transformProps.js
+++ b/superset/assets/src/visualizations/BigNumber/transformProps.js
@@ -29,6 +29,7 @@ export default function transformProps(chartProps) {
     compareLag: compareLagInput,
     compareSuffix = '',
     metric,
+    percentageMetric,
     showTrendLine,
     startYAxisAtZero,
     subheader = '',
@@ -44,13 +45,16 @@ export default function transformProps(chartProps) {
   }
 
   let bigNumber;
+  let bigNumberPercentage;
   let trendLineData;
   const metricName = metric && metric.label ? metric.label : metric;
+  const percentageMetricName = percentageMetric && percentageMetric.label ? percentageMetric.label : percentageMetric;
   const compareLag = +compareLagInput || 0;
   const supportTrendLine = vizType === 'big_number';
   const supportAndShowTrendLine = supportTrendLine && showTrendLine;
   let percentChange = 0;
   let formattedSubheader = subheader;
+  let formattedBigNumberPercentage = 0;
   if (supportTrendLine) {
     const sortedData = [...data].sort((a, b) => a[TIME_COLUMN] - b[TIME_COLUMN]);
     bigNumber = sortedData[sortedData.length - 1][metricName];
@@ -69,6 +73,15 @@ export default function transformProps(chartProps) {
       : null;
   } else {
     bigNumber = data[0][metricName];
+
+    if(percentageMetricName && data[0][percentageMetricName] >= 0) {
+      bigNumberPercentage = data[0][percentageMetricName] + '%';
+      // Uncomment the following code if we want to show the percent value with precisions.
+
+      //const formatPercentChange = getNumberFormatter(NumberFormats.PERCENT)
+      // formattedBigNumberPercentage = `${formatPercentChange(bigNumberPercentage)} %`;
+    }
+    
     trendLineData = null;
   }
 
@@ -85,6 +98,7 @@ export default function transformProps(chartProps) {
     width,
     height,
     bigNumber,
+    bigNumberPercentage,
     className,
     formatBigNumber: formatValue,
     mainColor,

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -64,7 +64,7 @@ stats_logger = config.get('STATS_LOGGER')
 relative_end = config.get('DEFAULT_RELATIVE_END_TIME', 'today')
 
 METRIC_KEYS = [
-    'metric', 'metrics', 'percent_metrics', 'metric_2', 'secondary_metric',
+    'metric', 'percentageMetric', 'metrics', 'percent_metrics', 'metric_2', 'secondary_metric',
     'x', 'y', 'size',
 ]
 
@@ -1094,7 +1094,13 @@ class BigNumberTotalViz(BaseViz):
         metric = self.form_data.get('metric')
         if not metric:
             raise Exception(_('Pick a metric!'))
-        d['metrics'] = [self.form_data.get('metric')]
+
+        if self.form_data['percentageMetric'] is not None:
+            percentageMetric = self.form_data.get('percentageMetric')
+            d['metrics'] = [metric, percentageMetric]
+        else: 
+            d['metrics'] = [metric]
+
         self.form_data['metric'] = metric
         return d
 


### PR DESCRIPTION
### CATEGORY

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
`BigNumberTotal` chart is now shown with two metrics, One with having absolute/percentage both and the other having only percentage

1. Kept font size same for both absolute and percentage fields
2. Relative to addition of one more field as percentage, I have not added another sub header as it looks cluttered. Only one sub header will be used to provide extra info.
3. The support of two metrics in only available in case of `BigNumberTotal` NOT in `BigNumberWithTrendline` Chart


### AFTER SCREENSHOTS OR ANIMATED GIF

<img width="1440" alt="Screenshot 2019-05-14 at 9 52 45 AM" src="https://user-images.githubusercontent.com/18305698/57670705-0e2e4f80-762e-11e9-800e-8e231f6579d3.png">


### TEST PLAN
NA

### ADDITIONAL INFORMATION

- [x] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@ankursinghal2005 
@arpit-agarwal 
@rasmi-ranjan-guavus 