### PR TITLE
#[UIC-1555] When user creates a chart for the first time, the subscriber layer shows the empty chart list

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2103,8 +2103,13 @@ export const controls = {
     mapStateToProps: (state) => {
       const newState = {};
       if (state.slices) {
-        newState.options = state.slices.filter(slice => state.slice ? (slice.id != state.slice.slice_id && slice.data.hasOwnProperty('publish_columns') && slice.data.publish_columns.length > 0) : false)
-          .map(slice => ({ label: slice.title, value: slice.id, columns: slice.column_names }));
+        newState.options = state.slices.filter(slice => {
+          const isPublishColumnExists = (slice.data.hasOwnProperty('publish_columns') && slice.data.publish_columns.length > 0);
+          if (state.slice) {
+            return (slice.id != state.slice.slice_id && isPublishColumnExists);
+          }
+          return isPublishColumnExists;
+        }).map(slice => ({ label: slice.title, value: slice.id, columns: slice.column_names }));
       }
       return newState;
     },


### PR DESCRIPTION
[UIC-1555](https://guavus-jira.atlassian.net/browse/UIC-1555)

### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When user creates a chart for the first time, the subscriber layer shows the empty chart list

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
When user creates a chart for the first time, the subscriber layer shows the empty chart list

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@jitendra-kumawat 