### PR TITLE
#[UIC-1620] Superset kube module not idempotent

### DIFF
--- a/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/tasks/main.yml
+++ b/superset-installer/etc/reflex-provisioner/roles/raf/superset/superset/tasks/main.yml
@@ -55,9 +55,11 @@
     - name: superset-deployment
       file: superset-deployment.yaml
       type: Deployment
+      state: reloaded
     - name: superset-service
       file: superset-service.yaml
       type: Service
+      state: reloaded
   register: superset_deploy_files
   when:
     - superset_deploy
@@ -86,6 +88,7 @@
     resource: "{{ item.item.type }}"
     filename: "{{ superset_host_k8s_dir }}/{{ item.item.file }}"
     state: "{{ item.changed | ternary('latest','present') }}"
+    state: "{{ item.item.state | default( item.changed | ternary('latest','present')) }}"
     force: "true"
   with_items: "{{ superset_deploy_files.results }}"
   when:


### PR DESCRIPTION
[UIC-1620](https://guavus-jira.atlassian.net/browse/UIC-1620)

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Re-running the playbook for superset fails when trying to kubectl create object that is declarative.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@bipinsoniguavus 