### PR TITLE
#[UIC-1742] Changed nginx port number to 11443 to avoid any conflict of port in RAF cluster

### DIFF
--- a/superset-installer/etc/reflex-provisioner/inventory/templates/group_vars/global/all/raf/superset.yml
+++ b/superset-installer/etc/reflex-provisioner/inventory/templates/group_vars/global/all/raf/superset.yml
@@ -70,8 +70,8 @@ superset_postgres_db_password: "{{ superset_sql_conn_creds['admin']['postgres'][
 
 superset_host_port: "8888"
 superset_docker_restart_policy: "Always"
-superset_service_port: "32443"
-superset_nginx_port: "32443"
+superset_service_port: "11443"
+superset_nginx_port: "11443"
 
 SUPERSET_NPROCESSORS: 1
 SUPERSET_SERVER_WORKER_TIMEOUT: 300 #in secs


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY

Changed nginx port number to 11443 to avoid any conflict of port in RAF cluster

1. No conflict with kubernetes services port as per service-node-port-range (default: 30000-32767) defined in /etc/kubernetes/manifests/kube-apiserver.manifest
2. No conflict with HDP 2.6.5 components configuration default ports. ref doc [here](https://docs.hortonworks.com/HDPDocuments/HDP3/HDP-3.1.0/administration/content/configuring-ports.html) 

For more info on `Kubernetes – Port, Targetport and NodePort`, read [this](https://vitalflux.com/kubernetes-port-targetport-and-nodeport/)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
NA

### TEST PLAN
NA

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@arpit-agarwal @ankursinghal2005 