### PR TITLE
#[UIC-1753]  publishing the timestamp of X-axis of line chart based on date is stored in backend

### DIFF
--- a/superset/assets/src/utils/pyToJsDateFormats.js
+++ b/superset/assets/src/utils/pyToJsDateFormats.js
@@ -1,0 +1,36 @@
+const pythonToJsFormats = Object.freeze({
+    '%a': 'ddd',
+    '%A': 'dddd',
+    '%w': 'd',
+    '%d': 'DD',
+    '%b': 'MMM',
+    '%B': 'MMMM',
+    '%m': 'MM',
+    '%y': 'YY',
+    '%Y': 'YYYY',
+    '%H': 'HH',
+    '%I': 'hh',
+    '%p': 'A',
+    '%M': 'mm',
+    '%S': 'ss',
+    '%f': 'SSS',
+    '%z': 'ZZ',
+    '%Z': 'z',
+    '%j': 'DDDD',
+    '%U': 'ww',		    // Week day of the year, Sunday first - not supported
+    '%W': 'ww',		    // Week day of the year, Monday first
+    '%c': 'ddd MMM DD HH:mm:ss YYYY',
+    '%x': 'MM/DD/YYYY',
+    '%X': 'HH:mm:ss',
+    '%%': '%'
+});
+
+export default function convertPyToJsDateFormat(format) {
+    var converted = format;
+    for (var name in pythonToJsFormats) {
+        if (pythonToJsFormats.hasOwnProperty(name)) {
+            converted = converted.split(name).join(pythonToJsFormats[name]);
+        }
+    }
+    return converted;
+};

--- a/superset/assets/src/visualizations/nvd3/transformProps.js
+++ b/superset/assets/src/visualizations/nvd3/transformProps.js
@@ -140,5 +140,6 @@ export default function transformProps(chartProps) {
     showOverlay,
     overlayLabel,
     tableFilter,
+    columns: datasource.columns,
   };
 }


### PR DESCRIPTION
[UIC-1753](https://guavus-jira.atlassian.net/browse/UIC-1753)

### CATEGORY

Choose one

- [X] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
1. On the click of line chart publishing the timestamp(X-axis), details table that is subscribing it is never populating the data since the timestamp on the backend in different date format 
2. We have resolved formatting issues in ndv3 file.
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@jitendra-kumawat 