### PR TITLE
#UIC-1885 User should able to replicate dashboard via a REST Call

### DIFF
--- a/knox/service.xml
+++ b/knox/service.xml
@@ -62,6 +62,10 @@
           <rewrite apply="SUPERSETUI/rvf/inbound/path-noslash" to="request.url"/>
           <rewrite apply="SUPERSETUI/rvf/outbound/headers" to="response.headers"/>
         </route>
+        <route path="/rvf/superset/replicate_dashboard">
+          <rewrite apply="SUPERSETUI/rvf/inbound/path-noslash" to="request.url"/>
+          <rewrite apply="SUPERSETUI/rvf/outbound/headers" to="response.headers"/>
+        </route>
         <route path="/rvf/superset/execute_rest_action">
           <rewrite apply="SUPERSETUI/rvf/inbound/path-noslash" to="request.url"/>
           <rewrite apply="SUPERSETUI/rvf/outbound/headers" to="response.headers"/>

--- a/superset/models/core.py
+++ b/superset/models/core.py
@@ -563,15 +563,16 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         # override the dashboard
         existing_dashboard = None
         existing_slug = None  
-        for dash in session.query(Dashboard).all():
-            # if ('remote_id' in dash.params_dict and
-            #         dash.params_dict['remote_id'] ==
-            #         dashboard_to_import.id):
-            #     existing_dashboard = dash
-            if (dash.slug == dashboard_to_import.slug):
-                existing_slug = True
-                logging.info('Dashboard with same slug exists. Dashboard id {} Dashboard title: {}'.format(
-                    dash.id, dash.dashboard_title))
+        if dashboard_to_import.slug is not None:
+            for dash in session.query(Dashboard).all():
+                # if ('remote_id' in dash.params_dict and
+                #         dash.params_dict['remote_id'] ==
+                #         dashboard_to_import.id):
+                #     existing_dashboard = dash
+                if (dash.slug == dashboard_to_import.slug):
+                    existing_slug = True
+                    logging.info('Dashboard with same slug exists. Dashboard id {} Dashboard title: {}'.format(
+                        dash.id, dash.dashboard_title))
         if existing_slug:
             flash(u'Dashboard with same slug exists. Update the slug and reimport', 'danger')
             session.rollback()
@@ -580,7 +581,6 @@ class Dashboard(Model, AuditMixinNullable, ImportMixin):
         if dashboard_to_import.position_json is not None:
             alter_positions(dashboard_to_import, old_to_new_slc_id_dict)
 
-        alter_positions(dashboard_to_import, old_to_new_slc_id_dict)
         dashboard_to_import.alter_params(import_time=import_time)
         if new_expanded_slices:
             dashboard_to_import.alter_params(

--- a/superset/utils/dashboard_import_export.py
+++ b/superset/utils/dashboard_import_export.py
@@ -22,6 +22,16 @@ import time
 from superset.models.core import Dashboard
 from superset.utils.core import decode_dashboards
 
+def dashboard_json(data):
+    return json.loads(data, object_hook=decode_dashboards)
+
+def import_dashboard_json(session, data, import_time=None):
+    current_tt = int(time.time())
+    import_time = current_tt if import_time is None else import_time
+    dashboard = data['dashboards'][0]
+    Dashboard.import_obj(
+            dashboard, import_time=import_time)
+    session.commit()
 
 def import_dashboards(session, data_stream, import_time=None):
     """Imports dashboards from a stream to databases"""

--- a/superset/views/add_to_dashboard.py
+++ b/superset/views/add_to_dashboard.py
@@ -37,11 +37,7 @@ def create_table(args):
     db.session.add(table_model)
     db.session.commit()
     logging.info('table is created with id = '+str(table_model.id)+' and linked with database id = '+str(database_id))
-    return {
-        'id' : table_model.id,
-        'type' : table_model.type,
-        'name' : table_model.name
-    }
+    return table_model
 
     
 def add_slice_to_dashboard(request,args, datasource_type=None, datasource_id=None):
@@ -93,12 +89,7 @@ def add_slice_to_dashboard(request,args, datasource_type=None, datasource_id=Non
     }
 
 
-def add_to_dashboard(request):
-    # create database  connection
-    database_name = request.form.get('database_name')
-    sqlalchemy_uri = request.form.get('sqlalchemy_uri')
-    extra = request.form.get('extra')
-    impersonate_user = eval(request.form.get('impersonate_user'))
+def create_database(database_name,sqlalchemy_uri,extra,impersonate_user):
     db_model = models.Database(
         database_name=database_name,
         sqlalchemy_uri=sqlalchemy_uri,
@@ -109,7 +100,15 @@ def add_to_dashboard(request):
     db.session.commit()
     database_id = db_model.id 
     logging.info('database connection is created with id = '+str(database_id))
-    
+    return database_id
+
+def add_to_dashboard(request):
+    # create database  connection
+    database_name = request.form.get('database_name')
+    sqlalchemy_uri = request.form.get('sqlalchemy_uri')
+    extra = request.form.get('extra')
+    impersonate_user = eval(request.form.get('impersonate_user'))
+    database_id = create_database(database_name,sqlalchemy_uri,extra,impersonate_user)    
 
     # create dashboard
     dash_model = models.Dashboard(

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -1340,14 +1340,6 @@ class Superset(BaseSupersetView):
             return redirect(url_for('DashboardAddView.list'))
         return self.render_template('superset/import_dashboards.html')
 
-    @expose('/import_dashboard_json', methods=['POST'])
-    def import_dashboard_json(self):
-        """Overrides the dashboards using json instances from the file."""
-        if request.method == 'POST':
-            dashboard_import_export.import_dashboards(db.session, request.data, is_stream=False)
-            return redirect(url_for('DashboardAddView.list'))
-        return self.render_template('superset/import_dashboards.html')
-
     @log_this
     @has_access
     @expose('/explorev2/<datasource_type>/<datasource_id>/')

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -863,12 +863,12 @@ class Superset(BaseSupersetView):
             database_id = create_database(database_name,sqlalchemy_uri,extra,impersonate_user)
 
         dashboard_title = request.form.get('dashboard_title')
-        tablesparam = json.loads(r''+request.form.get('tables'))
+        tables_param = json.loads(r''+request.form.get('tables'))
         template_parameters = {'dashboard_title': dashboard_title}
 
         if database_id is not None:
-            for table_placeholder in tablesparam:
-                schema_and_table_name = tablesparam[table_placeholder].split('.')
+            for table_placeholder in tables_param:
+                schema_and_table_name = tables_param[table_placeholder].split('.')
                 params = {
                     'database_id':database_id ,
                     'table_name': schema_and_table_name[1],

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -863,7 +863,7 @@ class Superset(BaseSupersetView):
             database_id = create_database(database_name,sqlalchemy_uri,extra,impersonate_user)
 
         dashboard_title = request.form.get('dashboard_title')
-        tablesparam = json.loads(request.form.get('tables'))
+        tablesparam = json.loads(r''+request.form.get('tables'))
         template_parameters = {'dashboard_title': dashboard_title}
 
         if database_id is not None:

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -66,6 +66,8 @@ from superset.superset_decorators import redirect_to_target_url
 from superset.utils import core as utils
 from superset.utils import dashboard_import_export
 from superset.utils.dates import now_as_float
+from superset.utils.core import decode_dashboards
+
 
 from .base import (
     api, BaseSupersetView,
@@ -75,7 +77,7 @@ from .base import (
     SupersetFilter, SupersetModelView, YamlExportMixin,
 )
 from .utils import bootstrap_user_data
-from .add_to_dashboard import add_to_dashboard
+from .add_to_dashboard import add_to_dashboard, create_database, create_table
 
 
 config = app.config
@@ -832,7 +834,65 @@ class Superset(BaseSupersetView):
             return json_success('OK')
         except Exception as e:
             logging.exception(e)
-            return json_error_response(e)  
+            return json_error_response(e) 
+
+    def update_dashboard(self, dashboards, parameters):
+        dashboard = dashboards['dashboards'][0]
+        title = parameters['dashboard_title']
+        if title:
+            dashboard.dashboard_title = title
+        # assuming sinle dashboard per JSON
+        for slice_item in dashboard.slices:
+            datasource = parameters[slice_item.datasource_name]
+            if datasource is not None:
+                slice_item.alter_params(
+                            datasource_name = datasource.name,
+                            schema = datasource.name,
+                            database_name = datasource.database_name,
+                        )
+        return dashboards
+    
+
+    @expose('/build_dashboard', methods=['POST'])
+    def build_dashboard(self):
+        database_name = request.form.get('database_name')
+        sqlalchemy_uri = request.form.get('sqlalchemy_uri')
+        extra = request.form.get('extra')
+        impersonate_user = eval(request.form.get('impersonate_user'))
+        if database_name is not None:
+            database_id = create_database(database_name,sqlalchemy_uri,extra,impersonate_user)
+
+        dashboard_title = request.form.get('dashboard_title')
+        tablesparam = json.loads(request.form.get('tables'))
+        template_parameters = {'dashboard_title': dashboard_title}
+
+        if database_id is not None:
+            for table_placeholder in tablesparam:
+                schema_and_table_name = tablesparam[table_placeholder].split('.')
+                params = {
+                    'database_id':database_id ,
+                    'table_name': schema_and_table_name[1],
+                    'schema': schema_and_table_name[0],
+                    'columns': json.dumps([])
+                }
+                # create table for slice
+                table = create_table(params)
+                table.fetch_metadata()
+                security_manager.merge_perm('datasource_access', table.get_perm())
+                if table.schema:
+                    security_manager.merge_perm('schema_access', table.schema_perm)
+                template_parameters[table_placeholder] = table
+
+                logging.info('table is created with id = '+str(table.id)+' and linked with database id = '+str(database_id)) 
+        
+        dashboard_data_param = request.form.get('template')
+        dashboard_data = dashboard_import_export.dashboard_json(dashboard_data_param)
+
+        self.update_dashboard(dashboard_data,template_parameters)
+
+        dashboard_import_export.import_dashboard_json(db.session, dashboard_data)
+        return redirect(url_for('DashboardAddView.list'))
+    
 
     @has_access_api
     @expose('/datasources/')
@@ -1277,6 +1337,14 @@ class Superset(BaseSupersetView):
         f = request.files.get('file')
         if request.method == 'POST' and f:
             dashboard_import_export.import_dashboards(db.session, f.stream)
+            return redirect(url_for('DashboardAddView.list'))
+        return self.render_template('superset/import_dashboards.html')
+
+    @expose('/import_dashboard_json', methods=['POST'])
+    def import_dashboard_json(self):
+        """Overrides the dashboards using json instances from the file."""
+        if request.method == 'POST':
+            dashboard_import_export.import_dashboards(db.session, request.data, is_stream=False)
             return redirect(url_for('DashboardAddView.list'))
         return self.render_template('superset/import_dashboards.html')
 

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -853,8 +853,8 @@ class Superset(BaseSupersetView):
         return dashboards
     
 
-    @expose('/build_dashboard', methods=['POST'])
-    def build_dashboard(self):
+    @expose('/replicate_dashboard', methods=['POST'])
+    def replicate_dashboard(self):
         database_name = request.form.get('database_name')
         sqlalchemy_uri = request.form.get('sqlalchemy_uri')
         extra = request.form.get('extra')

--- a/tests/security_tests.py
+++ b/tests/security_tests.py
@@ -249,6 +249,7 @@ class RolePermissionTests(SupersetTestCase):
             ['Superset', 'welcome'],
             ['Superset', 'addtodashboard'],
             ['Superset', 'execute_rest_action'],
+            ['Superset', 'replicate_dashboard'],
             ['TableModelView', 'create'],
             ['DatabaseView', 'create'],
             ['Dashboard', 'addnew'],


### PR DESCRIPTION
### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Exposed a `replicate_dashboard` endpoint to replicate a  dashboard from a given JSON template. 
**REST API Details**:
- endpoint: `superset/replicate_dashboard`
- headers: `none`
- database_name: `name of database to be created`
- sqlalchemy_uri: `uri for database connection as per sqlalchemy spec`
- extra: `additional configuration to establish connection via sqlalchemy_uri`
- impersonate_user: `True | False` case sensitive
- dashboard_title: `title of dashboard to be created`
- tables: `A map of tableplachoder as key and schema.table_name as value`
```
{"datasource_name": "default.master1_agg_stats_per_circle_15min"}
```
- template: `template json to be imported`
- csrf_token: `token received from /superset/csrf_token/ endpoint to avoid CSRF attack`

**Template JSON**:  User can create a template json by following steps
-  Open a RVF instance and go to dashboard list
- Select the dashboard you want to create as template
- Export the dashboard
- Remove `datasources` from the JSON. In case you won't remove it will be ignored
- for each slice in dashboard replace `datasource_name` with `tableplachoder`. Where `tableplachoder` is key in `tables` parameter corresponding to `datasource` to be used in this slice

**POSTMAN**: https://www.getpostman.com/collections/f1e82aece15702b7dc3a
### Expectation & Limitations
Feature set

1.  You should be able to create a new dashboard based own tempalte JSON
2. database connection and tables will be auto created

Limitation

1.  Table name has to be different per instance of REST API execution [[issue](https://guavus-jira.atlassian.net/browse/UIC-1720)]
2. Failure messages are not graceful 
3. Tables across database instance has to be unique [[issue](https://guavus-jira.atlassian.net/browse/UIC-1720)]
4. Only single database(hive instance) can be used in a dashboard.
5. Template JSOn should only have single dashboard serialised

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@jitendra-kumawat 