### PR TITLE
#[UIC-1973] Admin and dashboard viewer role without reset password permission

### DIFF
--- a/superset/security.py
+++ b/superset/security.py
@@ -528,7 +528,7 @@ class SupersetSecurityManager(SecurityManager):
         return not self.is_user_defined_permission(pvm)
 
     def is_admin_ldap_pvm(self, pvm):
-        return not self.is_reset_password_pvm(pvm) and self.is_admin_pvm(pvm)
+        return not (self.is_reset_my_password_pvm(pvm) or self.is_reset_passwords_pvm(pvm) or self.is_user_defined_permission(pvm))
 
     def is_alpha_pvm(self, pvm):
         return not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm))
@@ -550,7 +550,7 @@ class SupersetSecurityManager(SecurityManager):
              pvm.permission.name == 'can_list'))
 
     def is_dashboard_viewer_pvm(self, pvm):
-        return ( self.is_dashboard_viewer_ldap_pvm(pvm) or self.is_reset_password_pvm(pvm))
+        return ( self.is_dashboard_viewer_ldap_pvm(pvm) or self.is_reset_my_password_pvm(pvm))
 
     def is_dashboard_viewer_ldap_pvm(self, pvm):
         return ( self.is_base_view_pvm(pvm) or self.is_user_perm_pvm(pvm) or
@@ -574,11 +574,20 @@ class SupersetSecurityManager(SecurityManager):
             # but i am shortcircuiting thsi for now as those permission will be not added to role
             )
 
-    def is_reset_password_pvm(self, pvm):
+    def is_reset_my_password_pvm(self, pvm):
         return (
             pvm.permission.name in {
-                 'resetmypassword' , 'can_this_form_get' , 'can_this_form_post'
-            } and pvm.view_menu.name in {  'ResetMyPasswordView' }
+                 'resetmypassword' , 'can_this_form_get' , 'can_this_form_post', 'userinfoedit'
+            } and pvm.view_menu.name in {  'ResetMyPasswordView', 'UserDBModelView', 'UserInfoEditView' }
+            # above code will allow some options which are not in PVM
+            # but i am shortcircuiting thsi for now as those permission will be not added to role
+            )
+
+    def is_reset_passwords_pvm(self, pvm):
+        return (
+            pvm.permission.name in {
+                 'resetpasswords' , 'can_this_form_get' , 'can_this_form_post'
+            } and pvm.view_menu.name in {  'ResetPasswordView', 'UserDBModelView' }
             # above code will allow some options which are not in PVM
             # but i am shortcircuiting thsi for now as those permission will be not added to role
             )

--- a/superset/security.py
+++ b/superset/security.py
@@ -477,11 +477,13 @@ class SupersetSecurityManager(SecurityManager):
 
         # Creating default roles
         self.set_role('Admin', self.is_admin_pvm)
+        self.set_role('Admin_LDAP', self.is_admin_ldap_pvm)
         self.set_role('Alpha', self.is_alpha_pvm)
         self.set_role('Gamma', self.is_gamma_pvm)
         self.set_role('granter', self.is_granter_pvm)
         self.set_role('sql_lab', self.is_sql_lab_pvm)
         self.set_role('Dashboard_Viewer', self.is_dashboard_viewer_pvm)
+        self.set_role('Dashboard_Viewer_LDAP', self.is_dashboard_viewer_ldap_pvm)
 
         if conf.get('PUBLIC_ROLE_LIKE_GAMMA', False):
             self.set_role('Public', self.is_gamma_pvm)
@@ -525,6 +527,9 @@ class SupersetSecurityManager(SecurityManager):
     def is_admin_pvm(self, pvm):
         return not self.is_user_defined_permission(pvm)
 
+    def is_admin_ldap_pvm(self, pvm):
+        return not self.is_reset_password_pvm(pvm) and self.is_admin_pvm(pvm))
+
     def is_alpha_pvm(self, pvm):
         return not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm))
 
@@ -545,7 +550,10 @@ class SupersetSecurityManager(SecurityManager):
              pvm.permission.name == 'can_list'))
 
     def is_dashboard_viewer_pvm(self, pvm):
-        return ( self.is_base_view_pvm(pvm) or self.is_base_security_pvm(pvm) or
+        return ( self.is_dashboard_viewer_ldap_pvm(pvm) or self.is_reset_password_pvm(pvm))
+
+    def is_dashboard_viewer_ldap_pvm(self, pvm):
+        return ( self.is_base_view_pvm(pvm) or self.is_user_perm_pvm(pvm) or
             pvm.permission.name in {
                 'can_dashboard', 'can_explore_json', 'can_slice_json'
             } or (pvm.permission.name in {'can_list'} and pvm.view_menu.name in {'CssTemplateAsyncModelView', 'DashboardModelViewAsync' })
@@ -557,11 +565,20 @@ class SupersetSecurityManager(SecurityManager):
                 'can_fave_slices', 'can_fave_dashboards', 'can_recent_activity', 'can_favstar'
             })
 
-    def is_base_security_pvm(self, pvm):
+     def is_user_perm_pvm(self, pvm):
         return (
             pvm.permission.name in {
-                'can_userinfo' , 'resetmypassword' , 'can_this_form_get' , 'can_this_form_post'
-            } and pvm.view_menu.name in { 'UserDBModelView', 'ResetMyPasswordView' }
+                'can_userinfo' , 'can_this_form_get' , 'can_this_form_post'
+            } and pvm.view_menu.name in { 'UserDBModelView' }
+            # above code will allow some options which are not in PVM
+            # but i am shortcircuiting thsi for now as those permission will be not added to role
+            )
+
+    def is_reset_password_pvm(self, pvm):
+        return (
+            pvm.permission.name in {
+                 'resetmypassword' , 'can_this_form_get' , 'can_this_form_post'
+            } and pvm.view_menu.name in {  'ResetMyPasswordView' }
             # above code will allow some options which are not in PVM
             # but i am shortcircuiting thsi for now as those permission will be not added to role
             )

--- a/superset/security.py
+++ b/superset/security.py
@@ -528,7 +528,7 @@ class SupersetSecurityManager(SecurityManager):
         return not self.is_user_defined_permission(pvm)
 
     def is_admin_ldap_pvm(self, pvm):
-        return not self.is_reset_password_pvm(pvm) and self.is_admin_pvm(pvm))
+        return not self.is_reset_password_pvm(pvm) and self.is_admin_pvm(pvm)
 
     def is_alpha_pvm(self, pvm):
         return not (self.is_user_defined_permission(pvm) or self.is_admin_only(pvm))
@@ -565,7 +565,7 @@ class SupersetSecurityManager(SecurityManager):
                 'can_fave_slices', 'can_fave_dashboards', 'can_recent_activity', 'can_favstar'
             })
 
-     def is_user_perm_pvm(self, pvm):
+    def is_user_perm_pvm(self, pvm):
         return (
             pvm.permission.name in {
                 'can_userinfo' , 'can_this_form_get' , 'can_this_form_post'


### PR DESCRIPTION
### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
We have created new role that align with LDAP requirement of user should not be able to reset passwords from RVF interface

**feature set**

- "Admin_LDAP" role that can be used provide all access as admin except related to passwords
- "Dashboard_Viewer_LDAP" role that can be used provide all access as Dashboard_Viewer except related to my passwords

-  This could be used in connection with RAF deployment variable related to solve this bug by disabling password related functionality
```
         - name: AUTH_ROLE_ADMIN
          value: "{{ viz_fwk_auth_role_admin }}"
        - name: AUTH_USER_REGISTRATION_ROLE
          value: "{{ viz_fwk_auth_user_registration_role }}"
```
### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
**Admin Before** can reset self and others password
<img width="1308" alt="admin_other" src="https://user-images.githubusercontent.com/13412230/63586494-07b15b80-c5bf-11e9-9c14-276902c0e7be.png">
<img width="1420" alt="admin_self" src="https://user-images.githubusercontent.com/13412230/63586516-126bf080-c5bf-11e9-85ac-f919d005f033.png">

**Admin after**
<img width="1427" alt="admin_ldap_other" src="https://user-images.githubusercontent.com/13412230/63586691-96be7380-c5bf-11e9-8847-25a5aee0248c.png">
<img width="1431" alt="admin_ldap_self" src="https://user-images.githubusercontent.com/13412230/63586698-9a51fa80-c5bf-11e9-97cc-4cec10d70c18.png">

**Dashboard viewer before**
<img width="1439" alt="dashboard_viewer_self" src="https://user-images.githubusercontent.com/13412230/63586560-2d3e6500-c5bf-11e9-9b17-83c0a9703817.png">

**Dashboard viewer after**
<img width="1433" alt="dashboard_viewer_ldap_self" src="https://user-images.githubusercontent.com/13412230/63586719-ab027080-c5bf-11e9-8e7c-7f62e61c0299.png">

New perm on Dashboard viewer non-ldap
<img width="1438" alt="dashboard_viewer_new_perm" src="https://user-images.githubusercontent.com/13412230/63586742-bc4b7d00-c5bf-11e9-9ce0-5e29bae5b841.png">




### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [x] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
@jitendra-kumawat 