### PR TITLE
#[UIC-2110]:updated sliceoptions in slice formdata

### DIFF
--- a/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
+++ b/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
@@ -256,7 +256,7 @@ export default class SubscriberLayer extends React.PureComponent {
 
       Object.keys(this.state).forEach((k) => {
         // add checks of not dump sliceOptions in formdata ,it will fetch runtime always
-        if (this.state[k] !== null && k != 'sliceOptions') {
+        if ( k != 'sliceOptions' && this.state[k] !== null ) {
           subscription[k] = this.state[k];
         }
       });

--- a/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
+++ b/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
@@ -255,7 +255,8 @@ export default class SubscriberLayer extends React.PureComponent {
       const subscription = {};
 
       Object.keys(this.state).forEach((k) => {
-        if (this.state[k] !== null) {
+        // add checks of not dump sliceOptions in formdata ,it will fetch runtime always
+        if (this.state[k] !== null && k != 'sliceOptions') {
           subscription[k] = this.state[k];
         }
       });


### PR DESCRIPTION

### CATEGORY
This issue will occur if someone tried to add any slice as subscription layer in chart and that slice have large form_data ( here it is because of unwanted info in* subscriber_layer 's sliceOptions* property) and 
While saving slice after updating subscriber layer , REST API (https://rafa001-mgt-01.lab.guavus.com:8443/gateway/rafsso/rvf/dashboardasync/api/read?_flt_0_owners=2)
is called with request headers with more than allowed max HTTP header values (8k) .
Different servers have set default max limit as follows
*Apache/Jetty/Nginx/gunicorn - 8K
Tomcat - 8k-48K*

Ref links:--
https://www.tutorialspoint.com/What-is-the-maximum-size-of-HTTP-header-values
https://knox.apache.org/books/knox-0-14-0/user-guide.html#Gateway+Server+Configuration

so to fix this issue we have following options

1. Increase Max limit in Server configuration : At this setup superset is proxied by KNOX server and for KNOX server Request Header values max limit is 8K, so to increase this limit go to Ambari UI and add below property value in Knox Custom gateway-site Tab(updated over setup)
_gateway.httpserver.requestHeaderBuffer = 10240 _

2. Check/update/remove unwanted info before Importing dashboard .
3. Not save slice list in form_data of slice and fetch list on runtime while creating subscription layer as per owner.


,so in  this PR implementing **2nd and 3rd** approach to fix this issue.

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
