### PR TITLE
Fix timestamp on the timeseries based charts (UTC -> LOCAL TZ)

### DIFF
--- a/contrib/connectors/pandas/models.py
+++ b/contrib/connectors/pandas/models.py
@@ -58,7 +58,7 @@ class PandasDatabase(object):
     def __init__(self, database_name, cache_timeout=None):
         self.database_name = database_name
         self.cache_timeout = cache_timeout
-        self.data = {};
+        self.data = {}
 
     def __str__(self):
         return self.database_name
@@ -226,7 +226,7 @@ class PandasDatasource(Model, BaseDatasource):
 
     @property
     def description_markeddown(self):
-        return utils.markdown(self.description)
+        return utils.core.markdown(self.description)
 
     @property
     def link(self):
@@ -273,7 +273,7 @@ class PandasDatasource(Model, BaseDatasource):
         # Note that the front end uses `granularity_sqla` and
         # `time_grain_sqla` as the parameters for selecting the
         # column and time grain separately.
-        d['granularity_sqla'] = utils.choicify(self.dttm_cols)
+        d['granularity_sqla'] = utils.core.choicify(self.dttm_cols)
         d['time_grain_sqla'] = [(g, g) for g in self.GRAINS.keys()]
         logging.info(d)
         return d

--- a/superset/assets/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/components/DisplayQueryButton_spec.jsx
@@ -33,6 +33,7 @@ describe('DisplayQueryButton', () => {
     queryEndpoint: 'localhost',
     latestQueryFormData: {
       datasource: '1__table',
+      tz: 'UTC',
     },
   };
 

--- a/superset/assets/spec/javascripts/explore/utils_spec.jsx
+++ b/superset/assets/spec/javascripts/explore/utils_spec.jsx
@@ -26,6 +26,7 @@ describe('exploreUtils', () => {
   const location = window.location;
   const formData = {
     datasource: '1__table',
+    tz: 'UTC',
   };
   const sFormData = JSON.stringify(formData);
   const uri = new URI();

--- a/superset/assets/src/dashboard/containers/Chart.jsx
+++ b/superset/assets/src/dashboard/containers/Chart.jsx
@@ -53,7 +53,7 @@ function mapStateToProps(
     filters,
     sliceId: id,
     publishSubscriberMap,
-  })
+  });
 
   const dashboardTitle = ((undoableLayout.present[DASHBOARD_HEADER_ID] || {}).meta || {}).text;
 

--- a/superset/assets/src/explore/components/controls/DateFilterControl.jsx
+++ b/superset/assets/src/explore/components/controls/DateFilterControl.jsx
@@ -335,7 +335,7 @@ export default class DateFilterControl extends React.Component {
             <Tab eventKey={2} title="Custom">
               <FormGroup>
                 <PopoverSection
-                  title="Relative to today"
+                  title="Relative to now"
                   isSelected={this.state.type === TYPES.CUSTOM_RANGE}
                   onSelect={this.setTypeCustomRange}
                 >

--- a/superset/assets/src/explore/exploreUtils.js
+++ b/superset/assets/src/explore/exploreUtils.js
@@ -148,7 +148,14 @@ export function getExploreUrlAndPayload({
     });
   }
   uri = uri.search(search).directory(uri.prefix+directory);
-  const payload = { ...formData };
+
+  // Fetch client's timezone for timestamp conversion of charts to local TZ
+  let tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  // If this fails for some old unsupported browser, all the TZ handling will be done in UTC
+  if (tz === 'undefined') {
+    tz = 'UTC';
+  }
+  const payload = { ...formData, tz: tz };
 
   return {
     url: uri.toString(),

--- a/superset/config.py
+++ b/superset/config.py
@@ -584,7 +584,7 @@ WEBDRIVER_CONFIGURATION = {}
 WEBDRIVER_BASEURL = 'http://0.0.0.0:8080/'
 
 # add timezone and copyright property for footer display
-TIMEZONE = 'UTC'
+TIMEZONE = datetime.now(tz.tzlocal()).tzname()
 
 version_file = open(VERSION_FILE_PATH, 'r')
 APP_VERSION = version_file.read()
@@ -597,7 +597,7 @@ BUG_REPORT_URL = None
 # What is the Last N days relative in the time selector to:
 # 'today' means it is midnight (00:00:00) of today in the local timezone
 # 'now' means it is relative to the query issue time
-DEFAULT_RELATIVE_END_TIME = 'today'
+DEFAULT_RELATIVE_END_TIME = 'now'
 
 # Is epoch_s/epoch_ms datetime format supposed to be considered since UTC ?
 # If not, it is sassumed then the epoch_s/epoch_ms is seconds since 1/1/1970

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -146,7 +146,7 @@ class TableColumn(Model, BaseColumn):
             l.append(col <= text(self.dttm_sql_literal(end_dttm, is_epoch_in_utc)))
         return and_(*l)
 
-    def get_timestamp_expression(self, time_grain):
+    def get_timestamp_expression(self, time_grain, timezone):
         """Getting the time component of the query"""
         label = self.table.get_label(utils.DTTM_ALIAS)
 
@@ -163,7 +163,10 @@ class TableColumn(Model, BaseColumn):
                     f'No grain spec for {time_grain} for database {db.database_name}')
         expr = db.db_engine_spec.get_time_expr(
             self.expression or self.column_name,
-            pdf, time_grain, grain)
+            pdf,
+            time_grain,
+            grain,
+            timezone)
         return literal_column(expr, type_=DateTime).label(label)
 
     @classmethod
@@ -551,6 +554,7 @@ class SqlaTable(Model, BaseDatasource):
 
     def get_sqla_query(  # sqla
             self,
+            timezone,
             groupby, metrics,
             granularity,
             from_dttm, to_dttm,
@@ -643,7 +647,7 @@ class SqlaTable(Model, BaseDatasource):
             time_filters = []
 
             if is_timeseries:
-                timestamp = dttm_col.get_timestamp_expression(time_grain)
+                timestamp = dttm_col.get_timestamp_expression(time_grain, timezone)
                 select_exprs += [timestamp]
                 groupby_exprs_with_timestamp[timestamp.name] = timestamp
 

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -146,7 +146,7 @@ class TableColumn(Model, BaseColumn):
             l.append(col <= text(self.dttm_sql_literal(end_dttm, is_epoch_in_utc)))
         return and_(*l)
 
-    def get_timestamp_expression(self, time_grain, timezone):
+    def get_timestamp_expression(self, time_grain, timezone=None):
         """Getting the time component of the query"""
         label = self.table.get_label(utils.DTTM_ALIAS)
 
@@ -794,6 +794,7 @@ class SqlaTable(Model, BaseDatasource):
             else:
                 # run subquery to get top groups
                 subquery_obj = {
+                    'timezone': 'UTC',
                     'prequeries': prequeries,
                     'is_prequery': True,
                     'is_timeseries': False,

--- a/superset/db_engine_specs.py
+++ b/superset/db_engine_specs.py
@@ -120,15 +120,18 @@ class BaseEngineSpec(object):
             timezone = 'UTC'
         # if epoch, translate to DATE using db specific conf
         if pdf == 'epoch_s':
-            sub_expr = 'from_utc_timestamp(from_unixtime(%s), \'%s\')' % (expr, timezone)
+            expr = cls.epoch_to_dttm().format(col=expr)
+            if "from_unixtime" in expr:
+                expr = 'from_utc_timestamp(%s, \'%s\')' % (expr, timezone)
         elif pdf == 'epoch_ms':
             # As '/' is not supported in hive, we use DIV
-            expr = expr + ' DIV 1000'
-            sub_expr = 'from_utc_timestamp(from_unixtime(%s), \'%s\')' % (expr, timezone)
+            expr = cls.epoch_ms_to_dttm().format(col=expr)
+            if "from_unixtime" in expr:
+                expr = 'from_utc_timestamp(%s, \'%s\')' % (expr, timezone)
         if grain:
-            return grain.function.format(col=sub_expr)
+            return grain.function.format(col=expr)
         else:
-            return sub_expr
+            return expr
 
     @classmethod
     def get_time_grains(cls):
@@ -164,7 +167,7 @@ class BaseEngineSpec(object):
 
     @classmethod
     def epoch_ms_to_dttm(cls):
-        return cls.epoch_to_dttm().replace('{col}', '({col}/1000)')
+        return cls.epoch_to_dttm().replace('{col}', '({col} DIV 1000)')
 
     @classmethod
     def get_datatype(cls, type_code):

--- a/superset/templates/appbuilder/footer.html
+++ b/superset/templates/appbuilder/footer.html
@@ -3,7 +3,7 @@
 {% set copyright = appbuilder.app.config.get('COPYRIGHT') %}
 <div class="navbar navbar-default navbar-fixed-bottom navbar-template navbar-default-template navbar-fixed-bottom-template">
     <div class="footer-left">
-      <label class='footer-left-label'>{{ timezone }}</label>
+      <label class='footer-left-label'>SERVER TZ: {{ timezone }}</label>
     </div>
     <div class="footer-right">
         <label class='footer-right-label'>Version: {{ version }}  |  {{ copyright }}</label>

--- a/superset/viz.py
+++ b/superset/viz.py
@@ -128,6 +128,9 @@ class BaseViz(object):
                     label = utils.get_metric_name(o)
                     self.metric_dict[label] = o
 
+        # Get client's timezone for conversion of UTC Timestamps to Local TZ Timestamps
+        self.time_zone = fd.get("tz")
+
         # Cast to list needed to return serializable object in py3
         self.all_metrics = list(self.metric_dict.values())
         self.metric_labels = list(self.metric_dict.keys())
@@ -280,6 +283,7 @@ class BaseViz(object):
         """Building a query object"""
 
         has_kerberos_ticket()
+        client_tz = self.time_zone
         st_seconds = datetime.now()
         form_data = self.form_data
         self.process_query_filters()
@@ -333,6 +337,7 @@ class BaseViz(object):
         }
 
         d = {
+            'timezone': client_tz,
             'granularity': granularity,
             'from_dttm': from_dttm,
             'to_dttm': to_dttm,

--- a/tests/model_tests.py
+++ b/tests/model_tests.py
@@ -217,6 +217,7 @@ class SqlaTableModelTestCase(SupersetTestCase):
         arbitrary_metric = (dict(label='arbitrary', expressionType='SQL',
                                  sqlExpression='COUNT(1)'))
         query_obj = dict(
+            timezone='UTC',
             groupby=[arbitrary_gby, 'name'],
             metrics=[arbitrary_metric],
             filter=[],
@@ -262,6 +263,7 @@ class SqlaTableModelTestCase(SupersetTestCase):
     def test_sql_mutator(self):
         tbl = self.get_table_by_name('birth_names')
         query_obj = dict(
+            timezone='UTC',
             groupby=[],
             metrics=[],
             filter=[],


### PR DESCRIPTION
The previous behaviour on the time series based charts was that the time was represented in UTC which wasn't user-friendly.

After the fix, the timestamp is shown in the client's local timezone which is taken from the browser of the client.

Note: It also solves the problem of hive query failing for date-time columns (when in epoch_ms format) as hive doesn't support `/` operator rather it supports `DIV`

### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF

Screenshots are corresponding to `bintime = 1569906000` and `Timezone = Asia/Calcutta`

From epoch converter, results are:
`UTC = Tuesday, October 1, 2019 5:00:00 AM`
`IST = Tuesday, October 1, 2019 10:30:00 AM GMT+05:30`

We can hence verify the values from the chart where we have hovered on.

### Before:

Chart:
<img width="1440" alt="Before 1" src="https://user-images.githubusercontent.com/51480165/68697674-56123d00-05a5-11ea-9fad-6c0b9a72ba23.png">

Query:
<img width="1440" alt="Before 2" src="https://user-images.githubusercontent.com/51480165/68697697-62969580-05a5-11ea-9919-084012de331a.png">

### After:

Chart:
<img width="1440" alt="After 1" src="https://user-images.githubusercontent.com/51480165/68697712-6aeed080-05a5-11ea-9487-8f059b8519c4.png">

Query:
<img width="1440" alt="After 2" src="https://user-images.githubusercontent.com/51480165/68697718-6d512a80-05a5-11ea-93ea-6be5b21162b3.png">

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
