### PR TITLE
Feature [MIQ-2199]: Add support for date based partitions for hiveQL from Superset

### DIFF
--- a/superset/connectors/sqla/views.py
+++ b/superset/connectors/sqla/views.py
@@ -237,10 +237,10 @@ class TableModelView(DatasourceModelView, DeleteMixin, YamlExportMixin):  # noqa
             'A timeout of 0 indicates that the cache never expires. '
             'Note this defaults to the database timeout if undefined.'),
         'hive_partitions': utils.markdown(
-            '**Time based Hive partition schema sample **(supports till minute level)'
+            '**Date and Time based Hive partition schema sample **(supports till hour level for date and till minute level for time based)'
             '`{"time":{"year":"year_column","month":"month_column","day":"day_column",'
-            '"hour":"hr_column","minute":"min_column","bin_interval":900}}`'
-            ' Above schema can be defined till partition level (like hour, day, month etc.). '
+            '"hour":"hr_column","minute":"min_column","bin_interval":900}, "date":{"date":"date", "hour":"hour"}}`'
+            ' Above schema can be defined till partition level for time based (like hour, day, month etc.) and for date based (like date, hour) '
             '`bin_interval` is small common multiple of data aggregation intervals. '
             'Typical values **(in seconds)** are 300, 900, 1800, 3600 etc.',True ),
 

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -99,10 +99,9 @@ def get_partitioned_whereclause(_st, _en, gran_seconds, time_partitions):
 # Custom query for Hive Partitons (Date Based)
 def where_clause_date_based(_st, _en, date_partitions, grain):
     time_seq = list()
-
+    part_time_seq = list()
     if grain == 0:
-        # Partition = Date
-        part_time_seq = list()
+        # Partition = Date   
         date = date_partitions['date']
         if _st == _en:
             time_seq.append("(" + _st.strftime('`' + date + '`' + " = '%Y-%m-%d'") + ")")
@@ -111,7 +110,6 @@ def where_clause_date_based(_st, _en, date_partitions, grain):
             _st = _st + timedelta(seconds=GRAIN_VALUE_MAP['PT1D'])
     elif grain == 1:
         # Partition = Date, Hour
-        part_time_seq = list()
         date = date_partitions['date']
         hour = date_partitions['hour']
         if _st == _en:

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -103,8 +103,6 @@ def where_clause_date_based(_st, _en, date_partitions, grain):
     if grain == 0:
         # Partition = Date   
         date = date_partitions['date']
-        if _st == _en:
-            time_seq.append("(" + _st.strftime('`' + date + '`' + " = '%Y-%m-%d'") + ")")
         while _st <= _en:
             time_seq.append("(" + _st.strftime('`' + date + '`' + " = '%Y-%m-%d'") + ")")
             _st = _st + timedelta(seconds=GRAIN_VALUE_MAP['PT1D'])
@@ -112,11 +110,6 @@ def where_clause_date_based(_st, _en, date_partitions, grain):
         # Partition = Date, Hour
         date = date_partitions['date']
         hour = date_partitions['hour']
-        if _st == _en:
-            part_time_seq.append(_st.strftime('`' + date + '`' + " = '%Y-%m-%d'"))
-            part_time_seq.append(_st.strftime('`' + hour + '`' + " = '%H'"))
-            time_seq.append("(" + " AND ".join(part_time_seq) + ")")
-            part_time_seq.clear()
         while _st <= _en:
             part_time_seq.append(_st.strftime('`' + date + '`' + " = '%Y-%m-%d'"))
             part_time_seq.append(_st.strftime('`' + hour + '`' + " = '%H'"))

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -191,17 +191,18 @@ def default_hive_query_generator(sql, query_obj, database, datasource_name):
                 en = query_obj['to_dttm']
                 granularity = query_obj['granularity']
                 granularity_in_partitions = (granularity in date_partitions)
-                if 'date' in date_partitions:
-                    # TODO: Support upto Minutes, Seconds
-                    # Currently supported upto DATE (YYYY - MM - DD), HOUR (HH)
-                    if 'hour' in date_partitions:
-                        # Date, Hour based partition
-                        where_clause = where_clause_date_based(st, en, date_partitions, 1)
-                    else:
-                        # Date based partition
-                        where_clause = where_clause_date_based(st, en, date_partitions, 0)
-                sql_updated = replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
-                return sql_updated
+                if st and en:
+                    if 'date' in date_partitions:
+                        # TODO: Support upto Minutes, Seconds
+                        # Currently supported upto DATE (YYYY - MM - DD), HOUR (HH)
+                        if 'hour' in date_partitions:
+                            # Date, Hour based partition
+                            where_clause = where_clause_date_based(st, en, date_partitions, 1)
+                        else:
+                            # Date based partition
+                            where_clause = where_clause_date_based(st, en, date_partitions, 0)
+                    sql_updated = replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
+                    return sql_updated
 
             if 'date' not in hive_partitions_obj and 'time' in hive_partitions_obj:
                 time_partitions = (hive_partitions_obj['time'])

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -61,15 +61,15 @@ def get_partitions_min_grain(time_partitions):
 def get_partitioned_query_format(time_partitions):
     partition_seq = list()
     if 'year' in time_partitions:
-        partition_seq.append(time_partitions['year'] + " = %Y ")
+        partition_seq.append('`' + time_partitions['year'] + '`' + " = %Y ")
     if 'month' in time_partitions:
-        partition_seq.append(time_partitions['month'] + " = %m ")
+        partition_seq.append('`' + time_partitions['month'] + '`' + " = %m ")
     if 'day' in time_partitions:
-        partition_seq.append(time_partitions['day'] + " = %d ")
+        partition_seq.append('`' + time_partitions['day'] + '`' + " = %d ")
     if 'hour' in time_partitions:
-        partition_seq.append(time_partitions['hour'] + " = %H ")
+        partition_seq.append('`' + time_partitions['hour'] + '`' + " = %H ")
     if 'minute' in time_partitions:
-        partition_seq.append(time_partitions['minute'] + " = %M ")
+        partition_seq.append('`' + time_partitions['minute'] + '`' + " = %M ")
 
     partition_seq_str = "AND ".join(partition_seq)
     query_str = "( " + partition_seq_str + ")"

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -142,10 +142,8 @@ def replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_i
 
         sql_updated = re.sub(regex_st, where_clause, sql)
         sql_updated = re.sub(regex_et, '\n', sql_updated)
-        sql_updated = re.sub(' +', ' ', sql_updated)
     else:
         sql_updated = sql.replace("WHERE", " WHERE " + where_clause + " AND ")
-        sql_updated = re.sub(' +', ' ', sql_updated)
     return sql_updated
 
 def get_hive_partitions(database, datasource_name):

--- a/superset/hive_query.py
+++ b/superset/hive_query.py
@@ -16,23 +16,25 @@
 # under the License.
 # pylint: disable=C,R,W
 
-import json
 import re
-from datetime import timedelta
+import json
+import time
 import logging
-from datetime import datetime
-#gran valaue map,supported grain by hive db engine
+from datetime import timedelta, datetime
+
+# Grain valaue map, supported grain by hive db engine
 GRAIN_VALUE_MAP = {
-    'PT1S' : 1,
-    'PT1M' : 60,
-    'PT1H' : 3600,
-    'P1D'  : 86400,
-    'P1W'  : 604800,   # 7 days
-    'P1M'  : 2592000,  # 30 days
-    'P3M'  : 7776000,  # 3*30 days
-    'P0.25Y': 7776000, # 3*30 days
-    'P1Y'  : 31536000  # 365 days
+    'PT1S': 1,
+    'PT1M': 60,
+    'PT1H': 3600,
+    'P1D': 86400,
+    'P1W': 604800,   # 7 days
+    'P1M': 2592000,  # 30 days
+    'P3M': 7776000,  # 3*30 days
+    'P0.25Y': 7776000,  # 3*30 days
+    'P1Y': 31536000  # 365 days
 }
+
 
 def get_partitions_min_grain(time_partitions):
     if 'bin_interval' in time_partitions:
@@ -56,22 +58,21 @@ def get_partitions_min_grain(time_partitions):
     return None
 
 
-
 def get_partitioned_query_format(time_partitions):
     partition_seq = list()
     if 'year' in time_partitions:
-        partition_seq.append(time_partitions['year']+" = %Y ")
+        partition_seq.append(time_partitions['year'] + " = %Y ")
     if 'month' in time_partitions:
-        partition_seq.append(time_partitions['month']+" = %m ")
+        partition_seq.append(time_partitions['month'] + " = %m ")
     if 'day' in time_partitions:
-        partition_seq.append(time_partitions['day']+" = %d ")
+        partition_seq.append(time_partitions['day'] + " = %d ")
     if 'hour' in time_partitions:
-        partition_seq.append(time_partitions['hour']+" = %H ")
+        partition_seq.append(time_partitions['hour'] + " = %H ")
     if 'minute' in time_partitions:
-        partition_seq.append(time_partitions['minute']+" = %M ")
-   
+        partition_seq.append(time_partitions['minute'] + " = %M ")
+
     partition_seq_str = "AND ".join(partition_seq)
-    query_str  = "( "+ partition_seq_str+ ")"
+    query_str = "( " + partition_seq_str + ")"
     return query_str
 
 def get_partitioned_whereclause(_st, _en, gran_seconds, time_partitions):
@@ -95,49 +96,114 @@ def get_partitioned_whereclause(_st, _en, gran_seconds, time_partitions):
 
     return where_clause
 
+# Custom query for Hive Partitons (Date Based)
+def where_clause_date_based(_st, _en, date_partitions, grain):
+    time_seq = list()
+
+    if grain == 0:
+        # Partition = Date
+        part_time_seq = list()
+        date = date_partitions['date']
+        if _st == _en:
+            time_seq.append("(" + _st.strftime('`' + date + '`' + " = '%Y-%m-%d'") + ")")
+        while _st <= _en:
+            time_seq.append("(" + _st.strftime('`' + date + '`' + " = '%Y-%m-%d'") + ")")
+            _st = _st + timedelta(seconds=GRAIN_VALUE_MAP['PT1D'])
+    elif grain == 1:
+        # Partition = Date, Hour
+        part_time_seq = list()
+        date = date_partitions['date']
+        hour = date_partitions['hour']
+        if _st == _en:
+            part_time_seq.append(_st.strftime('`' + date + '`' + " = '%Y-%m-%d'"))
+            part_time_seq.append(_st.strftime('`' + hour + '`' + " = '%H'"))
+            time_seq.append("(" + " AND ".join(part_time_seq) + ")")
+            part_time_seq.clear()
+        while _st <= _en:
+            part_time_seq.append(_st.strftime('`' + date + '`' + " = '%Y-%m-%d'"))
+            part_time_seq.append(_st.strftime('`' + hour + '`' + " = '%H'"))
+            time_seq.append("(" + " AND ".join(part_time_seq) + ")")
+            part_time_seq.clear()
+            _st = _st + timedelta(seconds=GRAIN_VALUE_MAP['PT1H'])
+    # TODO = Partition support for minute, second
+
+    where_clause = " OR ".join(time_seq)
+    if time_seq and len(time_seq) > 1:
+        where_clause = "(" + where_clause + ")"
+    return where_clause
+
+
 def replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions):
     sql_updated = sql
     if granularity_in_partitions:
         # regex for  `granularity` >= 1549497600 type of string
         # any word regex (?:[a-z][a-z]+)
-        regex_st = "(`)("+granularity+")(`)(\\s+)(>)(=)(\\s+)(\\d+)"
+        regex_st = "(`)(" + granularity + ")(`)(\\s+)(>)(=)(\\s+)(\\d+)"
         # regex for `granularity` <= 1549497600
-        regex_et = "(AND)(\\s+)(`)("+granularity+")(`)(\\s+)(<)(=)(\\s+)(\\d+)"
+        regex_et = "(AND)(\\s+)(`)(" + granularity + ")(`)(\\s+)(<)(=)(\\s+)(\\d+)"
 
         sql_updated = re.sub(regex_st, where_clause, sql)
         sql_updated = re.sub(regex_et, '\n', sql_updated)
+        sql_updated = re.sub(' +', ' ', sql_updated)
     else:
-        sql_updated = sql.replace("WHERE", " WHERE "+ where_clause +" AND ")
+        sql_updated = sql.replace("WHERE", " WHERE " + where_clause + " AND ")
+        sql_updated = re.sub(' +', ' ', sql_updated)
     return sql_updated
 
 def get_hive_partitions(database, datasource_name):
-    tables = list(filter(lambda tname: (tname.datasource_name == datasource_name), database.tables))
+    tables = list(filter(lambda tname: (
+        tname.datasource_name == datasource_name), database.tables))
     table = tables[0]
     return table.hive_partitions
 
 def default_hive_query_generator(sql, query_obj, database, datasource_name):
     st_seconds = datetime.now()
-    """ schema for time based partition in table
+
+    """ 
+    Schema for time and date based partition in table
     {
-      "time":{
-                "year":"year",
-                "month":"month",
-                "day":"day",
-                "hour":"hour",
-                "minute":"minute",
-                "bin_interval":900
-         }
+      "time": {
+            "year":"year",
+            "month":"month",
+            "day":"day",
+            "hour":"hour",
+            "minute":"minute",
+            "bin_interval":900
+        },
+        "date": {
+            "date": "date",
+            "hour": "hour"
+        }
     }
 
-     Here we replace simply default time range based
-     where clause from sql to specific partition based  where clause
-     and returning update sql
+    Here we replace simply default date/ time range based
+    where clause from sql to specific partition based  where clause
+    and returning update sql
     """
+
     if database.backend == 'hive' and query_obj['extras']['query_with_partitions']:
         hive_partitions = get_hive_partitions(database, datasource_name)
         if hive_partitions:
             hive_partitions_obj = json.loads(hive_partitions)
-            if 'time' in hive_partitions_obj:
+            if 'date' in hive_partitions_obj:
+                date_partitions = (hive_partitions_obj['date'])
+                st = query_obj['from_dttm']
+                en = query_obj['to_dttm']
+                granularity = query_obj['granularity']
+                granularity_in_partitions = (granularity in date_partitions)
+                if 'date' in date_partitions:
+                    # TODO: Support upto Minutes, Seconds
+                    # Currently supported upto DATE (YYYY - MM - DD), HOUR (HH)
+                    if 'hour' in date_partitions:
+                        # Date, Hour based partition
+                        where_clause = where_clause_date_based(st, en, date_partitions, 1)
+                    else:
+                        # Date based partition
+                        where_clause = where_clause_date_based(st, en, date_partitions, 0)
+                sql_updated = replace_whereclause_in_org_sql(granularity, sql, where_clause, granularity_in_partitions)
+                return sql_updated
+
+            if 'date' not in hive_partitions_obj and 'time' in hive_partitions_obj:
                 time_partitions = (hive_partitions_obj['time'])
                 st = query_obj['from_dttm']
                 en = query_obj['to_dttm']

--- a/tests/hivequery_tests.py
+++ b/tests/hivequery_tests.py
@@ -48,19 +48,19 @@ class HivePartitionQueryTestCase(unittest.TestCase):
         t_p_1 = {
             "year":"y"
         }
-        self.assertEqual(get_partitioned_query_format(t_p_1),"( y = %Y )")
+        self.assertEqual(get_partitioned_query_format(t_p_1),"( `y` = %Y )")
         t_p_2 = {
             "year":"y",
             "month":"m"
         }
-        self.assertEqual(get_partitioned_query_format(t_p_2),"( y = %Y AND m = %m )")
+        self.assertEqual(get_partitioned_query_format(t_p_2),"( `y` = %Y AND `m` = %m )")
 
         t_p_3 = {
             "year":"y",
             "month":"m",
             "day":"d",
         }
-        self.assertEqual(get_partitioned_query_format(t_p_3),"( y = %Y AND m = %m AND d = %d )")
+        self.assertEqual(get_partitioned_query_format(t_p_3),"( `y` = %Y AND `m` = %m AND `d` = %d )")
 
         t_p_4 = {
             "year":"y",
@@ -68,7 +68,7 @@ class HivePartitionQueryTestCase(unittest.TestCase):
             "day":"d",
             "hour":"hr"
         }
-        self.assertEqual(get_partitioned_query_format(t_p_4),"( y = %Y AND m = %m AND d = %d AND hr = %H )")
+        self.assertEqual(get_partitioned_query_format(t_p_4),"( `y` = %Y AND `m` = %m AND `d` = %d AND `hr` = %H )")
 
         t_p_5 = {
             "year":"y",
@@ -77,13 +77,13 @@ class HivePartitionQueryTestCase(unittest.TestCase):
             "hour":"hr",
             "minute":"min"
         }
-        self.assertEqual(get_partitioned_query_format(t_p_5),"( y = %Y AND m = %m AND d = %d AND hr = %H AND min = %M )")
+        self.assertEqual(get_partitioned_query_format(t_p_5),"( `y` = %Y AND `m` = %m AND `d` = %d AND `hr` = %H AND `min` = %M )")
         t_p_6 = {
             "month":"m",
             "day":"d",
             "hour":"hr",
         }
-        self.assertEqual(get_partitioned_query_format(t_p_6),"( m = %m AND d = %d AND hr = %H )")
+        self.assertEqual(get_partitioned_query_format(t_p_6),"( `m` = %m AND `d` = %d AND `hr` = %H )")
 
     def test_get_partitioned_whereclause(self):
         from_date_time_str = '2019-01-01 10:00:00'
@@ -97,18 +97,18 @@ class HivePartitionQueryTestCase(unittest.TestCase):
             "hour":"hr",
         }
         grain =  get_partitions_min_grain(t_p_5)
-        updated_sql = "( y = 2019 AND m = 01 AND d = 01 AND hr = 10 )" 
+        updated_sql = "( `y` = 2019 AND `m` = 01 AND `d` = 01 AND `hr` = 10 )" 
         self.assertEqual(get_partitioned_whereclause(from_date_time_obj,to_date_time_obj,grain,t_p_5),updated_sql)
 
     def test_replace_whereclause_in_org_sql(self):
         granularity = 'timestamp'
         sql = "WHERE `timestamp` >= '20190411000000' AND `timestamp` <= '20190412000000' AND `c_call_completed` >= 2"
-        where_clause = "( y = 2019 AND m = 01 AND d = 01 AND hr = 10 )" 
-        response = " WHERE ( y = 2019 AND m = 01 AND d = 01 AND hr = 10 ) AND  `timestamp` >= '20190411000000' AND `timestamp` <= '20190412000000' AND `c_call_completed` >= 2"
+        where_clause = "( `y` = 2019 AND `m` = 01 AND `d` = 01 AND `hr` = 10 )" 
+        response = " WHERE ( `y` = 2019 AND `m` = 01 AND `d` = 01 AND `hr` = 10 ) AND  `timestamp` >= '20190411000000' AND `timestamp` <= '20190412000000' AND `c_call_completed` >= 2"
         self.assertEqual(replace_whereclause_in_org_sql(granularity, sql, where_clause, False),response)
 
         sql = "WHERE `timestamp` >= 20190411000000 AND `timestamp` <= 20190412000000 AND `c_call_completed` >= 2"
-        response_1 = "WHERE ( y = 2019 AND m = 01 AND d = 01 AND hr = 10 ) \n AND `c_call_completed` >= 2"
+        response_1 = "WHERE ( `y` = 2019 AND `m` = 01 AND `d` = 01 AND `hr` = 10 ) \n AND `c_call_completed` >= 2"
         self.assertEqual(replace_whereclause_in_org_sql(granularity, sql, where_clause, True),response_1)
 
 


### PR DESCRIPTION
### CATEGORY
Currently, it supports up to partitions like Date/ Hour. Please do review it.

The feature was implemented keeping in mind the best practices while making partitions in hive. Now superset will support queries to hive which are partitioned on the basis of date (%Y-%m-%d)

Ref: [Best Practices for Hive Partitions by Date](https://community.cloudera.com/t5/Support-Questions/Best-Pratices-for-Hive-Partitioning-especially-by-Date/m-p/112525)

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
