### PR TITLE
#[UIC-2319]:Added support to pass on slice selections as filters to navigated dashboard

### DIFF
--- a/superset/assets/src/chart/chartAction.js
+++ b/superset/assets/src/chart/chartAction.js
@@ -380,6 +380,12 @@ export function executeRestAction(payload, restAction, timeout) {
       ...restAction,
       data: createPostPayload(restAction.data,payload)
     };
+    
+    // update url with filters info as queryparmas for nvaigatetodashbaord rest action
+    if ("get" === (restAction.method).toLowerCase() && Object.keys(payload.filters).length > 0) {
+      var queryparams="?preslice_filters="+encodeURIComponent(JSON.stringify(payload.filters));
+      restAction.url += queryparams;
+    }
     dispatch(runRestQuery(restAction,timeout, chart.id));
   };
 }

--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -99,6 +99,14 @@ export default function (bootstrapData) {
     return defaultFilters;
   }
 
+  try {
+    // parse preslice_filters from uri and store it in filters against preslice_filters key
+    const preslice_filters =  JSON.parse(getParam('preslice_filters'));
+    filters['preslice_filters'] = preslice_filters;
+  } catch (error) {
+    console.log('no preslice_filters found in url')
+  }
+
   // try {
   //   // allow request parameter overwrite dashboard metadata
   //   filters = JSON.parse(

--- a/superset/assets/src/dashboard/util/charts/getFormDataWithExtraFilters.js
+++ b/superset/assets/src/dashboard/util/charts/getFormDataWithExtraFilters.js
@@ -84,6 +84,9 @@ export default function getFormDataWithExtraFilters({
   sliceId,
   publishSubscriberMap = undefined,
 }) {
+  
+  // store preslice_filters
+  const preslice_filters = filters && filters.hasOwnProperty('preslice_filters') ? filters['preslice_filters'] : undefined;
 
   const subscriberSliceMap = getSubscriberSliceMap(publishSubscriberMap, sliceId);
 
@@ -99,6 +102,11 @@ export default function getFormDataWithExtraFilters({
     !!cachedFormdataByChart[sliceId]
   ) {
     return cachedFormdataByChart[sliceId];
+  }
+
+  // set preslice_filters
+  if(preslice_filters){
+    filters['preslice_filters']  = preslice_filters;
   }
 
   const formData = {


### PR DESCRIPTION


### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
Added support to pass on slice selections as filters to navigated dashboard

Workflow:-
1.All published selections of particular slice will be passed as filter to navigating dashboard
2.All passed on filters will be applied to all charts of navigated dashboard with `in` operator
3.These filters will be maintained till page is live in browser , not saved in slice metadata to restore.


### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
