### PR TITLE
MIQ-2274: Add datasource info for published slices

### DIFF
--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2149,7 +2149,7 @@ export const controls = {
             return (slice.id != state.slice.slice_id && isPublishColumnExists);
           }
           return isPublishColumnExists;
-        }).map(slice => ({ label: slice.title, value: slice.id, columns: slice.column_names }));
+        }).map(slice => ({ label: slice.title + " (" + slice.datasource + ")" , value: slice.id, columns: slice.column_names }));
       }
       return newState;
     },

--- a/superset/views/core.py
+++ b/superset/views/core.py
@@ -2045,6 +2045,7 @@ class Superset(BaseSupersetView):
                 publish_columns = o.Slice.form_data['publish_columns']
             obj = {
                 'id': o.Slice.id,
+                'datasource': '%s' % o.Slice.datasource,
                 'title': o.Slice.slice_name,
                 'url': o.Slice.slice_url,
                 'column_names': publish_columns,


### PR DESCRIPTION
When replicating dashboards with charts, the subscriber layer lists charts with duplicated names which makes harder for the user to link the publisher and subscriber correctly. While the motive of replication of dashboards is to use it with different datasources, so adding the datasource of the slices in the filter box selector would improve the experience of the administrator who's working the dashboards.

This commit adds datasource info appended with the slice's name in the subscriber layer's "Select chart" filter.

### CATEGORY

Choose one

- [ ] Bug Fix
- [x] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
1) Duplicate dashboards along with the charts
2) Go to the duplicated charts and change the data source
3) Now go to the subscriber layer of the newly created charts
4) Check if charts with same are differentiated on the basis of the data sources (Datasource is suffixed and enclosed in bracket)
5) And test if publisher-subscriber is working

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
