### PR TITLE
fix(leaflet-logger): Added logger in leaflet map

### DIFF
--- a/superset/assets/src/visualizations/LeafletMap/LeafletMap.js
+++ b/superset/assets/src/visualizations/LeafletMap/LeafletMap.js
@@ -25,6 +25,8 @@ import * as L from '../../../node_modules/leaflet/dist/leaflet.js';
 import * as esri from '../../../node_modules/esri-leaflet/dist/esri-leaflet.js';
 import * as GRAPHICON from './graphIcon.js';
 import PropTypes from 'prop-types';
+import { Logger, LOG_ACTIONS_RENDER_CHART_CONTAINER } from '../../logger';
+
 
 const propTypes = {
     payload: PropTypes.object,
@@ -424,7 +426,15 @@ function LeafletMap(element, props) {
         drawMap();
     }
 
-    init();
+    try {
+      init();
+    } catch (err) {
+      Logger.append(LOG_ACTIONS_RENDER_CHART_CONTAINER, {
+        has_err: true,
+        error_details: err.toString()
+      }, true);
+      console.log(err);
+    }
 }
 
 LeafletMap.displayName = 'Leaflet Map';


### PR DESCRIPTION
[UIC-1667](https://guavus-jira.atlassian.net/browse/UIC-1667)

### CATEGORY

Choose one

- [x] Bug Fix
- [ ] Enhancement (new features, refinement)
- [ ] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
In Geo-map, when user tries to create a map with idcolum of type BIGINT Geomap crashes
So here
 - added logger 
- added exception and push on server

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
