### PR TITLE
fix(pub-sub-retain): Retain pub-sub information 

### DIFF
--- a/superset/assets/src/dashboard/reducers/getInitialState.js
+++ b/superset/assets/src/dashboard/reducers/getInitialState.js
@@ -64,7 +64,7 @@ export default function (bootstrapData) {
   const isPublishColumnExistsInFilters = (filterConfigFilters, col) => {
     return (Object.keys(filterConfigFilters).length > 0 && filterConfigFilters[col] != undefined && Object.keys(filterConfigFilters[col]).length > 0);
   }
-  
+
   const getSliceData = (sliceId, slices) => {
     let slice_data = _.find(slices, function (slice) {
       return (slice.slice_id == sliceId);
@@ -148,7 +148,18 @@ export default function (bootstrapData) {
   const sliceIds = new Set();
   const modalSliceIds = new Set();
 
+  var oldToNewSliceIdMap = dashboard.slices.reduce((map, slice) => {
+    map[slice.form_data.remote_id] = slice.slice_id;
+    return map;
+  }, {});
+
   dashboard.slices.forEach(slice => {
+    if (slice.form_data && slice.form_data.subscriber_layers) {
+      slice.form_data.subscriber_layers.forEach(layer => {
+        layer.sliceId = oldToNewSliceIdMap[layer.sliceId]
+      })
+    }
+
     const key = slice.slice_id;
     if (['separator', 'markup'].indexOf(slice.form_data.viz_type) === -1) {
       chartQueries[key] = {

--- a/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
+++ b/superset/assets/src/explore/components/controls/SubscriberLayer.jsx
@@ -25,7 +25,7 @@ import PopoverSection from '../../../components/PopoverSection';
 import TextControl from './TextControl';
 import CheckboxControl from './CheckboxControl';
 import { nonEmpty } from '../../validators';
-import { uniq } from 'lodash';
+import { uniq, find } from 'lodash';
 
 const propTypes = {
   name: PropTypes.string,
@@ -130,14 +130,8 @@ export default class SubscriberLayer extends React.PureComponent {
   }
 
   getPublishedColumns(sliceId) {
-    let sliceColumns = [];
-    this.props.sliceOptions.forEach(slice => {
-      if (slice.value === sliceId) {
-        sliceColumns = slice.columns;
-        return sliceColumns;
-      }
-    });
-    return sliceColumns;
+    const columnObj = find(this.props.sliceOptions, ['remoteId', sliceId]);
+    return columnObj ? columnObj.columns : [];
   }
 
   getRefactoredPublishedColumns(pubSliceCols) {
@@ -395,6 +389,7 @@ export default class SubscriberLayer extends React.PureComponent {
                 name="publised-layer-name"
                 options={publishedSlices}
                 value={sliceId}
+                valueKey='remoteId'
                 onChange={this.handleSliceType}
               />
 

--- a/superset/assets/src/explore/controls.jsx
+++ b/superset/assets/src/explore/controls.jsx
@@ -2149,7 +2149,7 @@ export const controls = {
             return (slice.id != state.slice.slice_id && isPublishColumnExists);
           }
           return isPublishColumnExists;
-        }).map(slice => ({ label: slice.title + " (" + slice.datasource + ")" , value: slice.id, columns: slice.column_names }));
+        }).map(slice => ({ label: slice.title + " (" + slice.datasource + ")" , value: slice.id, remoteId: slice.data.remote_id, columns: slice.column_names }));
       }
       return newState;
     },
@@ -2201,7 +2201,7 @@ export const controls = {
     mapStateToProps: (state) => {
       const newState = {};
       if (state.slices) {
-        newState.options = state.slices.filter(slice => state.slice ? slice.id != state.slice.slice_id : true).map(slice => ({ label: slice.title, value: slice.id }))
+        newState.options = state.slices.filter(slice => state.slice ? slice.id != state.slice.slice_id : true).map(slice => ({ label: slice.title, value: slice.id, remoteId: slice.data.remote_id }))
       }
       return newState;
     }


### PR DESCRIPTION
[UIC-1540](https://guavus-jira.atlassian.net/browse/UIC-1540)

### CATEGORY

Choose one

- [x] Bug Fix
- [x] Enhancement (new features, refinement)
- [x] Refactor
- [ ] Add tests
- [ ] Build / Development Environment
- [ ] Documentation

### SUMMARY
When we view dashboard than for each slice created new slice_id (file /Guavus/incubator-superset/superset/models/core.py, function : import_obj line no: 546 )

This new slice_id which is updated everywhere in dashboard object but not updated in slice\[form_data\]\[subscriber_layer\] (which we use to create pub/sub map)

So, at frontend side code when create publisher-subscriber array/map, contain old_id, so here mismatch occur when try compare and pub/sub not work

* this is also fixable at backend side (in python code)
* tried to update array in python code but not able to update so done fix at frontend side(javascript code)

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->

### TEST PLAN
<!--- What steps should be taken to verify the changes -->

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Changes UI
- [ ] Requires DB Migration.
- [ ] Confirm DB Migration upgrade and downgrade tested.
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API

### REVIEWERS
